### PR TITLE
fix: update doc-gardening prompt for TarmacView

### DIFF
--- a/scripts/doc-gardening-prompt.md
+++ b/scripts/doc-gardening-prompt.md
@@ -4,70 +4,54 @@ Scan this repository for stale, outdated, or inaccurate documentation and fix it
 
 ## Documentation Files to Scan
 
-- `README.md` — project overview, harness table, quick start, architecture summary
+- `README.md` — project overview, quick start, architecture summary
 - `CLAUDE.md` — agent instructions: build commands, code style, architecture, critical paths, security constraints, PR conventions
-- `docs/architecture.md` — detailed project structure, component diagram, layer descriptions, data flow, ADRs
-- `docs/conventions.md` — coding conventions, naming rules, import order, exports, error handling, formatting, testing, git workflow
-- `docs/layers.md` — layer boundary definitions, dependency matrix, enforcement, common violations
+- `docs/conventions.md` — coding conventions, naming rules, import order, error handling, formatting, testing, git workflow
+- `docs/specs/SPEC.md` — domain model, enum values, trajectory formulas, UI page specs, status rules
+- `docs/specs/DESIGN-SYSTEM.md` — visual design system, color palette, typography, spacing, component patterns
 
 ## Scanning Checklist
 
 ### 1. Broken File References
 
-- Search all five markdown files for backtick-quoted paths (e.g., `` `src/core/detector.ts` ``), markdown links, and inline references to source files.
+- Search all markdown files for backtick-quoted paths (e.g., `` `backend/app/services/` ``), markdown links, and inline references to source files.
 - Verify each referenced file still exists at that path by reading the filesystem.
 - If a file was moved, update the reference to the new location.
 - If a file was deleted with no replacement, remove the reference and note the deletion.
-- Pay special attention to references in `docs/architecture.md` — the project structure tree and layer descriptions list specific filenames.
+- Pay special attention to directory tree listings in `CLAUDE.md` — the project structure section lists specific directories and files.
 
 ### 2. Command Accuracy
 
-Read `package.json` and compare its `scripts` section against documented commands in `CLAUDE.md` and `README.md`:
+Read `backend/pyproject.toml`, `backend/requirements.txt`, and `frontend/package.json` and compare against documented commands in `CLAUDE.md` and `README.md`:
 
-| Expected Script | Expected Command | Source |
-|---|---|---|
-| `build` | `tsup` | `CLAUDE.md`, `README.md` |
-| `dev` | `tsup --watch` | `CLAUDE.md` |
-| `test` | `vitest run` | `CLAUDE.md`, `README.md` |
-| `lint` | `eslint src/` | `CLAUDE.md`, `README.md` |
-| `typecheck` | `tsc --noEmit` | `CLAUDE.md` |
-| `prepare` | `husky` | — |
+- Backend commands: `pip install`, `uvicorn`, `pytest`, `ruff check`, `ruff format`
+- Frontend commands: `npm install`, `npm run dev`, `npm run build`, `npm run lint`, `npx vitest run`
+- Database: `docker compose up -d`
 
-If any script name, command, or `npm run` invocation in the docs no longer matches `package.json`, update it. Flag commands documented in markdown that have no corresponding `package.json` script.
+If any command in the docs no longer matches the actual tooling, update it.
 
 ### 3. Architecture Drift
 
-Compare `docs/architecture.md` against the actual directory structure under `src/`:
+Compare `CLAUDE.md` project structure section against the actual directory structure:
 
-- **Expected layers**: `commands/`, `core/`, `harnesses/`, `prompts/`, `providers/`, `ui/`, `utils/`
-- **Expected harness modules** (13 files in `src/harnesses/`): `risk-contract`, `claude-md`, `ci-pipeline`, `docs-structure`, `pre-commit-hooks`, `risk-policy-gate`, `review-agent`, `architectural-linters`, `remediation-loop`, `browser-evidence`, `garbage-collection`, `pr-templates`, `incident-harness-loop`
-- **Expected prompt files** (matching harness modules, plus `system.ts`, `detect-stack.ts`, `types.ts`)
-- **Expected utils files**: `errors.ts`, `fs.ts`, `git.ts`, `harness-config.ts`, `template.ts`
+- **Backend**: `backend/app/api/routes/`, `backend/app/core/`, `backend/app/models/`, `backend/app/schemas/`, `backend/app/services/`
+- **Frontend**: `frontend/src/pages/`, `frontend/src/components/`, `frontend/src/contexts/`, `frontend/src/api/`, `frontend/src/i18n/`, `frontend/src/types/`
+- **Frontend components**: `common/`, `mission/`, `map/`, `Layout/`, `Auth/`
+- **Map layers**: `frontend/src/components/map/layers/` and `frontend/src/components/map/overlays/`
 
-If modules have been added, renamed, or removed since the docs were last written, update the architecture docs accordingly.
+If directories or key files have been added, renamed, or removed since the docs were last written, update the docs accordingly.
 
 ### 4. CLAUDE.md Accuracy
 
 Verify each section of `CLAUDE.md` against the actual project state:
 
-1. **Build & Run Commands** — must match `package.json` scripts exactly.
-2. **Code Style Rules** — cross-check against `.prettierrc` (single quotes, semicolons, trailing commas, 100-char width, 2-space indent) and `eslint.config.js`.
-3. **Architecture Overview** — the directory tree must match actual `src/` contents.
-4. **Dependency rule** — the import boundaries table must match `architecturalBoundaries` in `harness.config.json`.
-5. **Critical Paths** — the listed files must match the Tier 3 paths implied by `harness.config.json` risk tiers.
-6. **Security Constraints** — verify claims are still accurate (e.g., Zod validation in `detector.ts`, tool whitelisting in `claude-runner.ts`).
+1. **Build & Run Commands** — must match actual tooling.
+2. **Code Style Rules** — cross-check against `backend/pyproject.toml` (ruff config) and `frontend/eslint.config.js`.
+3. **Project Structure** — the directory tree must match actual contents.
+4. **Critical Paths** — the listed paths must match the Tier 3 patterns in `harness.config.json`.
+5. **DDD-Lite Patterns** — verify referenced model methods and value objects still exist.
 
-### 5. Harness Config Consistency
-
-Read `harness.config.json` and verify:
-
-- `commands.test`, `commands.build`, `commands.lint`, `commands.typeCheck` match the actual `package.json` scripts.
-- `architecturalBoundaries` layers match the actual `src/` subdirectories.
-- `docsDrift.trackedDocs` lists all documentation files that exist.
-
-If `harness.config.json` has drifted, note the discrepancy as a `<!-- TODO: ... -->` comment in `CLAUDE.md` — do not modify `harness.config.json` directly.
-
-### 6. Broken Internal Links
+### 5. Broken Internal Links
 
 Check all markdown links in both `[text](url)` and `[text][ref]` styles:
 
@@ -75,29 +59,21 @@ Check all markdown links in both `[text](url)` and `[text][ref]` styles:
 - For heading anchors (e.g., `#architecture-overview`), verify the heading exists in the target file.
 - For external links, leave them as-is — do not attempt to verify or fix.
 
-### 7. Stale Code Examples
-
-Find code examples in documentation that reference imports, functions, classes, or interfaces:
-
-- Verify referenced symbols still exist in the codebase with the documented signatures.
-- Check that import paths use `.js` extensions (ESM requirement).
-- Update examples if the API has changed; leave a `<!-- TODO: ... -->` if the replacement is unclear.
-
-### 8. Workflow and Script References
+### 6. Workflow and Script References
 
 Verify that references to CI workflows and scripts in documentation match actual files:
 
-- **Expected workflows** in `.github/workflows/`: `ci.yml`, `code-review-agent.yml`, `remediation-agent.yml`, `review-agent-rerun.yml`, `risk-policy-gate.yml`, `structural-tests.yml`, `harness-smoke.yml`, `auto-resolve-threads.yml`, `doc-gardening.yml`
-- **Expected scripts** in `scripts/`: `lint-architecture.ts`, `lint-architecture-config.json`, `remediation-agent-prompt.md`, `remediation-guard.ts`, `review-agent-utils.ts`, `review-prompt.md`, `risk-policy-gate.sh`, `risk-policy-gate.ts`, `structural-tests.sh`, `doc-gardening-prompt.md`
+- Check `.github/workflows/` for actual workflow files.
+- Check `scripts/` for actual script files.
+- Check `.codefactory/prompts/` for actual prompt files.
 
 ## Rules
 
 - Only modify documentation files (`*.md`, `*.mdx`, `*.rst`).
-- **NEVER** modify source code (`.ts`, `.js`), configuration files (`.json`, `.yml`, `.yaml`), or CI workflows.
+- **NEVER** modify source code (`.py`, `.ts`, `.tsx`, `.js`), configuration files (`.json`, `.yml`, `.yaml`, `.toml`), or CI workflows.
 - When removing a stale reference, check if there is a replacement to link to.
 - Preserve each document's structure, tone, heading hierarchy, and formatting.
 - If unsure about a change, leave a `<!-- TODO: verify — [description] -->` comment rather than guessing.
-- Add `<!-- Last gardened: YYYY-MM-DD -->` to sections you have verified or updated.
 - Do not rewrite paragraphs for style — only fix factual inaccuracies and broken references.
 - Do not add new sections or documentation — only maintain what already exists.
 


### PR DESCRIPTION
## Summary
- Replace copy-pasted CodeFactory template with TarmacView-specific scanning checklist
- References actual project files: backend (Python/FastAPI), frontend (React/TypeScript), docs
- Fixes CI failure where agent exhausted 10 turns searching for non-existent files

## Risk Tier
- [x] T1 (documentation only)

Generated with [Claude Code](https://claude.com/claude-code)