### PR TITLE
fix: bump issue planner agent max turns to 60

### DIFF
--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-6 --max-turns 60 --allowedTools "Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Extract plan from execution file


### PR DESCRIPTION
## Summary
- Bump `--max-turns` from 30 to 60 in `issue-planner.yml` so the planner agent can finish analyzing larger issues without hitting the turn limit.

## Why
The planner failed on issue #97 because it ran out of turns while exploring a larger multi-task issue body.

## Risk Tier
T1 — workflow config only, no application code touched.

## Test plan
- [ ] Re-trigger planner on issue #97 by re-applying `agent:plan` label after merge
- [ ] Confirm planner runs to completion within the 15-min timeout