### PR TITLE
feat: recalculate dimensions + feature info bundle (#97)

### DIFF
--- a/backend/app/api/routes/airports.py
+++ b/backend/app/api/routes/airports.py
@@ -230,7 +230,10 @@ def delete_terrain_dem(airport_id: UUID, db: Session = Depends(get_db)):
     airport_service.delete_terrain_dem(db, airport_id)
 
     if old_dem_path and os.path.exists(old_dem_path):
-        os.unlink(old_dem_path)
+        try:
+            os.unlink(old_dem_path)
+        except OSError:
+            logger.warning("failed to unlink old DEM file: %s", old_dem_path)
 
     return DeleteResponse(deleted=True)
 

--- a/backend/app/api/routes/airports.py
+++ b/backend/app/api/routes/airports.py
@@ -38,6 +38,7 @@ from app.schemas.infrastructure import (
     LHAUpdate,
     ObstacleCreate,
     ObstacleListResponse,
+    ObstacleRecalculateResponse,
     ObstacleResponse,
     ObstacleUpdate,
     SafetyZoneCreate,
@@ -46,6 +47,7 @@ from app.schemas.infrastructure import (
     SafetyZoneUpdate,
     SurfaceCreate,
     SurfaceListResponse,
+    SurfaceRecalculateResponse,
     SurfaceResponse,
     SurfaceUpdate,
 )
@@ -320,6 +322,15 @@ def delete_surface(airport_id: UUID, surface_id: UUID, db: Session = Depends(get
     return DeleteResponse(deleted=True)
 
 
+@router.post(
+    "/{airport_id}/surfaces/{surface_id}/recalculate",
+    response_model=SurfaceRecalculateResponse,
+)
+def recalculate_surface(airport_id: UUID, surface_id: UUID, db: Session = Depends(get_db)):
+    """recompute surface length/width/heading from geometry without persisting."""
+    return airport_service.recalculate_surface_dimensions(db, airport_id, surface_id)
+
+
 # obstacles
 @router.get("/{airport_id}/obstacles", response_model=ObstacleListResponse)
 def list_obstacles(airport_id: UUID, db: Session = Depends(get_db)):
@@ -349,6 +360,15 @@ def delete_obstacle(airport_id: UUID, obstacle_id: UUID, db: Session = Depends(g
     airport_service.delete_obstacle(db, airport_id, obstacle_id)
 
     return DeleteResponse(deleted=True)
+
+
+@router.post(
+    "/{airport_id}/obstacles/{obstacle_id}/recalculate",
+    response_model=ObstacleRecalculateResponse,
+)
+def recalculate_obstacle(airport_id: UUID, obstacle_id: UUID, db: Session = Depends(get_db)):
+    """recompute obstacle dimensions from boundary geometry without persisting."""
+    return airport_service.recalculate_obstacle_dimensions(db, airport_id, obstacle_id)
 
 
 # safety zones

--- a/backend/app/models/airport.py
+++ b/backend/app/models/airport.py
@@ -6,6 +6,12 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.core.database import Base
+from app.core.geometry import parse_ewkb
+from app.utils.geo import (
+    bearing_between,
+    linestring_length,
+    polygon_oriented_dimensions,
+)
 
 
 class Airport(Base):
@@ -95,6 +101,44 @@ class AirfieldSurface(Base):
         ),
     )
 
+    def recalculate_dimensions(self) -> dict:
+        """compute length, width, heading from stored geometry without persisting.
+
+        length and heading derive from the centerline linestring. width derives
+        from the boundary polygon's perpendicular OBB axis when available;
+        otherwise the existing width is preserved.
+        """
+        length = self.length
+        width = self.width
+        heading = self.heading
+
+        # centerline-derived length and heading
+        if self.geometry is not None:
+            line_geo = parse_ewkb(self.geometry.data)
+            line_coords = line_geo.get("coordinates", [])
+            if len(line_coords) >= 2:
+                length = linestring_length(line_coords)
+                start = line_coords[0]
+                end = line_coords[-1]
+                heading = bearing_between(start[0], start[1], end[0], end[1])
+
+        # boundary-derived width via OBB perpendicular to centerline
+        if self.boundary is not None:
+            poly_geo = parse_ewkb(self.boundary.data)
+            rings = poly_geo.get("coordinates", [])
+            if rings:
+                obb_length, obb_width, _ = polygon_oriented_dimensions(rings[0])
+                if obb_width > 0:
+                    width = obb_width
+                if length is None and obb_length > 0:
+                    length = obb_length
+
+        return {
+            "length": length,
+            "width": width,
+            "heading": heading,
+        }
+
 
 class Runway(AirfieldSurface):
     """runway surface subtype."""
@@ -137,6 +181,31 @@ class Obstacle(Base):
             name="ck_obstacle_type",
         ),
     )
+
+    def recalculate_dimensions(self) -> dict:
+        """compute length, width, heading from the stored polygon boundary.
+
+        derives an oriented bounding box from the boundary's outer ring.
+        radius is half of the smaller OBB axis (useful for circular-ish obstacles).
+        """
+        length = 0.0
+        width = 0.0
+        heading = 0.0
+
+        if self.boundary is not None:
+            poly_geo = parse_ewkb(self.boundary.data)
+            rings = poly_geo.get("coordinates", [])
+            if rings:
+                length, width, heading = polygon_oriented_dimensions(rings[0])
+
+        radius = width / 2.0 if width > 0 else 0.0
+
+        return {
+            "length": length,
+            "width": width,
+            "heading": heading,
+            "radius": radius,
+        }
 
 
 class SafetyZone(Base):

--- a/backend/app/schemas/infrastructure.py
+++ b/backend/app/schemas/infrastructure.py
@@ -75,6 +75,8 @@ class ObstacleUpdate(BaseModel):
     boundary: PolygonZ | None = None
     buffer_distance: float | None = Field(default=None, ge=0)
     type: str | None = None
+    # transport-only flag - skip ground-altitude renormalization on this update
+    preserve_altitude: bool = False
 
 
 class ObstacleResponse(BaseModel):
@@ -148,6 +150,8 @@ class LHAUpdate(BaseModel):
     transition_sector_width: float | None = None
     lamp_type: str | None = None
     position: PointZ | None = None
+    # transport-only flag - skip ground-altitude renormalization on this update
+    preserve_altitude: bool = False
 
 
 class LHAResponse(BaseModel):
@@ -186,6 +190,8 @@ class AGLUpdate(BaseModel):
     glide_slope_angle: float | None = None
     distance_from_threshold: float | None = None
     offset_from_centerline: float | None = None
+    # transport-only flag - skip ground-altitude renormalization on this update
+    preserve_altitude: bool = False
 
 
 class AGLResponse(BaseModel):
@@ -203,6 +209,38 @@ class AGLResponse(BaseModel):
     lhas: list[LHAResponse] = []
 
     model_config = {"from_attributes": True}
+
+
+# recalculate dimensions responses
+class SurfaceDimensions(BaseModel):
+    """surface dimensions snapshot"""
+
+    length: float | None = None
+    width: float | None = None
+    heading: float | None = None
+
+
+class SurfaceRecalculateResponse(BaseModel):
+    """response for surface recalculate dimensions endpoint"""
+
+    current: SurfaceDimensions
+    recalculated: SurfaceDimensions
+
+
+class ObstacleDimensions(BaseModel):
+    """obstacle dimensions snapshot"""
+
+    length: float | None = None
+    width: float | None = None
+    heading: float | None = None
+    radius: float | None = None
+
+
+class ObstacleRecalculateResponse(BaseModel):
+    """response for obstacle recalculate dimensions endpoint"""
+
+    current: ObstacleDimensions
+    recalculated: ObstacleDimensions
 
 
 # list responses

--- a/backend/app/schemas/infrastructure.py
+++ b/backend/app/schemas/infrastructure.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -5,13 +6,21 @@ from pydantic import BaseModel, Field
 from app.schemas.common import ListMeta
 from app.schemas.geometry import LineStringZ, PointZ, PolygonZ
 
+# enum-bounded string aliases - mirror the db check constraints so invalid
+# values fail with a clean 422 instead of a 500 IntegrityError at commit
+SurfaceTypeStr = Literal["RUNWAY", "TAXIWAY"]
+ObstacleTypeStr = Literal["BUILDING", "TOWER", "ANTENNA", "VEGETATION", "OTHER"]
+SafetyZoneTypeStr = Literal["CTR", "RESTRICTED", "PROHIBITED", "TEMPORARY_NO_FLY"]
+LampTypeStr = Literal["HALOGEN", "LED"]
+PAPISideStr = Literal["LEFT", "RIGHT"]
+
 
 # surfaces for airport
 class SurfaceCreate(BaseModel):
     """surface create schema"""
 
     identifier: str
-    surface_type: str
+    surface_type: SurfaceTypeStr
     geometry: LineStringZ
     boundary: PolygonZ | None = None
     buffer_distance: float = Field(default=5.0, ge=0)  # 0 = use raw boundary, no expansion
@@ -42,7 +51,7 @@ class SurfaceResponse(BaseModel):
     id: UUID
     airport_id: UUID
     identifier: str
-    surface_type: str
+    surface_type: SurfaceTypeStr
     geometry: LineStringZ
     boundary: PolygonZ | None = None
     buffer_distance: float = 5.0
@@ -64,7 +73,7 @@ class ObstacleCreate(BaseModel):
     height: float
     boundary: PolygonZ
     buffer_distance: float = Field(default=5.0, ge=0)  # 0 = use raw boundary, no expansion
-    type: str
+    type: ObstacleTypeStr
 
 
 class ObstacleUpdate(BaseModel):
@@ -74,7 +83,7 @@ class ObstacleUpdate(BaseModel):
     height: float | None = None
     boundary: PolygonZ | None = None
     buffer_distance: float | None = Field(default=None, ge=0)
-    type: str | None = None
+    type: ObstacleTypeStr | None = None
     # transport-only flag - skip ground-altitude renormalization on this update
     preserve_altitude: bool = False
 
@@ -88,7 +97,7 @@ class ObstacleResponse(BaseModel):
     height: float
     boundary: PolygonZ
     buffer_distance: float
-    type: str
+    type: ObstacleTypeStr
 
     model_config = {"from_attributes": True}
 
@@ -98,7 +107,7 @@ class SafetyZoneCreate(BaseModel):
     """safety zone create schema"""
 
     name: str
-    type: str
+    type: SafetyZoneTypeStr
     geometry: PolygonZ
     altitude_floor: float | None = None
     altitude_ceiling: float | None = None
@@ -109,7 +118,7 @@ class SafetyZoneUpdate(BaseModel):
     """safety zone update schema"""
 
     name: str | None = None
-    type: str | None = None
+    type: SafetyZoneTypeStr | None = None
     geometry: PolygonZ | None = None
     altitude_floor: float | None = None
     altitude_ceiling: float | None = None
@@ -122,7 +131,7 @@ class SafetyZoneResponse(BaseModel):
     id: UUID
     airport_id: UUID
     name: str
-    type: str
+    type: SafetyZoneTypeStr
     geometry: PolygonZ
     altitude_floor: float | None = None
     altitude_ceiling: float | None = None
@@ -138,7 +147,7 @@ class LHACreate(BaseModel):
     unit_number: int
     setting_angle: float
     transition_sector_width: float | None = None
-    lamp_type: str
+    lamp_type: LampTypeStr
     position: PointZ
 
 
@@ -148,7 +157,7 @@ class LHAUpdate(BaseModel):
     unit_number: int | None = None
     setting_angle: float | None = None
     transition_sector_width: float | None = None
-    lamp_type: str | None = None
+    lamp_type: LampTypeStr | None = None
     position: PointZ | None = None
     # transport-only flag - skip ground-altitude renormalization on this update
     preserve_altitude: bool = False
@@ -162,7 +171,7 @@ class LHAResponse(BaseModel):
     unit_number: int
     setting_angle: float
     transition_sector_width: float | None = None
-    lamp_type: str
+    lamp_type: LampTypeStr
     position: PointZ
 
     model_config = {"from_attributes": True}
@@ -174,7 +183,7 @@ class AGLCreate(BaseModel):
     agl_type: str
     name: str
     position: PointZ
-    side: str | None = None
+    side: PAPISideStr | None = None
     glide_slope_angle: float | None = None
     distance_from_threshold: float | None = None
     offset_from_centerline: float | None = None
@@ -186,7 +195,7 @@ class AGLUpdate(BaseModel):
     agl_type: str | None = None
     name: str | None = None
     position: PointZ | None = None
-    side: str | None = None
+    side: PAPISideStr | None = None
     glide_slope_angle: float | None = None
     distance_from_threshold: float | None = None
     offset_from_centerline: float | None = None
@@ -202,7 +211,7 @@ class AGLResponse(BaseModel):
     agl_type: str
     name: str
     position: PointZ
-    side: str | None = None
+    side: PAPISideStr | None = None
     glide_slope_angle: float | None = None
     distance_from_threshold: float | None = None
     offset_from_centerline: float | None = None

--- a/backend/app/schemas/inspection_template.py
+++ b/backend/app/schemas/inspection_template.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 from app.schemas.common import ListMeta
+from app.schemas.mission import CaptureModeStr, InspectionMethodStr
 
 
 class InspectionConfigCreate(BaseModel):
@@ -18,7 +19,7 @@ class InspectionConfigCreate(BaseModel):
     horizontal_distance: float | None = None
     sweep_angle: float | None = None
     lha_ids: list[UUID] | None = None
-    capture_mode: str | None = None
+    capture_mode: CaptureModeStr | None = None
     recording_setup_duration: float | None = None
     buffer_distance: float | None = Field(default=None, ge=0)
 
@@ -36,7 +37,7 @@ class InspectionConfigResponse(BaseModel):
     horizontal_distance: float | None = None
     sweep_angle: float | None = None
     lha_ids: list[UUID] | None = None
-    capture_mode: str | None = None
+    capture_mode: CaptureModeStr | None = None
     recording_setup_duration: float | None = None
     buffer_distance: float | None = None
 
@@ -52,7 +53,7 @@ class InspectionTemplateCreate(BaseModel):
     created_by: str | None = None
     default_config: InspectionConfigCreate | None = None
     target_agl_ids: list[UUID] = []
-    methods: list[str] = []
+    methods: list[InspectionMethodStr] = []
 
 
 class InspectionTemplateUpdate(BaseModel):
@@ -62,7 +63,7 @@ class InspectionTemplateUpdate(BaseModel):
     description: str | None = None
     angular_tolerances: dict | None = None
     target_agl_ids: list[UUID] | None = None
-    methods: list[str] | None = None
+    methods: list[InspectionMethodStr] | None = None
     default_config: InspectionConfigCreate | None = None
 
 
@@ -78,7 +79,7 @@ class InspectionTemplateResponse(BaseModel):
     updated_at: datetime | None = None
     default_config: InspectionConfigResponse | None = None
     target_agl_ids: list[UUID] = []
-    methods: list[str] = []
+    methods: list[InspectionMethodStr] = []
     mission_count: int = 0
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/mission.py
+++ b/backend/app/schemas/mission.py
@@ -1,10 +1,16 @@
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
 from app.schemas.common import ListMeta
 from app.schemas.geometry import PointZ
+
+# inspection method values - mirrors InspectionMethod enum
+InspectionMethodStr = Literal["VERTICAL_PROFILE", "ANGULAR_SWEEP"]
+# capture mode values - used by trajectory_computation to choose camera_action
+CaptureModeStr = Literal["VIDEO_CAPTURE", "PHOTO_CAPTURE"]
 
 
 class InspectionConfigOverride(BaseModel):
@@ -19,7 +25,7 @@ class InspectionConfigOverride(BaseModel):
     horizontal_distance: float | None = None
     sweep_angle: float | None = None
     lha_ids: list[UUID] | None = None
-    capture_mode: str | None = None
+    capture_mode: CaptureModeStr | None = None
     recording_setup_duration: float | None = None
     buffer_distance: float | None = Field(default=None, ge=0)
 
@@ -36,14 +42,14 @@ class InspectionCreate(BaseModel):
     """add inspection to mission"""
 
     template_id: UUID
-    method: str
+    method: InspectionMethodStr
     config: InspectionConfigOverride | None = None
 
 
 class InspectionUpdate(BaseModel):
     """update inspection within mission"""
 
-    method: str | None = None
+    method: InspectionMethodStr | None = None
     config: InspectionConfigOverride | None = None
     sequence_order: int | None = None
 
@@ -60,7 +66,7 @@ class InspectionConfigResponse(BaseModel):
     horizontal_distance: float | None = None
     sweep_angle: float | None = None
     lha_ids: list[UUID] | None = None
-    capture_mode: str | None = None
+    capture_mode: CaptureModeStr | None = None
     recording_setup_duration: float | None = None
     buffer_distance: float | None = None
 
@@ -74,7 +80,7 @@ class InspectionResponse(BaseModel):
     mission_id: UUID
     template_id: UUID
     config_id: UUID | None = None
-    method: str
+    method: InspectionMethodStr
     sequence_order: int
     lha_ids: list[UUID] | None = None
     config: InspectionConfigResponse | None = None
@@ -105,7 +111,7 @@ class MissionCreate(BaseModel):
     default_altitude_offset: float | None = None
     takeoff_coordinate: PointZ | None = None
     landing_coordinate: PointZ | None = None
-    default_capture_mode: str | None = None
+    default_capture_mode: CaptureModeStr | None = None
     default_buffer_distance: float | None = Field(default=None, ge=0)
 
 
@@ -120,7 +126,7 @@ class MissionUpdate(BaseModel):
     takeoff_coordinate: PointZ | None = None
     landing_coordinate: PointZ | None = None
     date_time: datetime | None = None
-    default_capture_mode: str | None = None
+    default_capture_mode: CaptureModeStr | None = None
     default_buffer_distance: float | None = Field(default=None, ge=0)
 
 
@@ -140,7 +146,7 @@ class MissionResponse(BaseModel):
     default_altitude_offset: float | None = None
     takeoff_coordinate: PointZ | None = None
     landing_coordinate: PointZ | None = None
-    default_capture_mode: str | None = None
+    default_capture_mode: CaptureModeStr | None = None
     default_buffer_distance: float | None = None
     has_unsaved_map_changes: bool = False
     inspection_count: int = 0

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -300,6 +300,26 @@ def delete_surface(db: Session, airport_id: UUID, surface_id: UUID):
     db.commit()
 
 
+def recalculate_surface_dimensions(db: Session, airport_id: UUID, surface_id: UUID) -> dict:
+    """compute surface length/width/heading from geometry, returns current + recalculated."""
+    surface = (
+        db.query(AirfieldSurface)
+        .filter(AirfieldSurface.id == surface_id, AirfieldSurface.airport_id == airport_id)
+        .first()
+    )
+    if not surface:
+        raise NotFoundError("surface not found")
+
+    return {
+        "current": {
+            "length": surface.length,
+            "width": surface.width,
+            "heading": surface.heading,
+        },
+        "recalculated": surface.recalculate_dimensions(),
+    }
+
+
 # obstacles
 
 
@@ -440,8 +460,8 @@ def update_obstacle(
     if not obstacle:
         raise NotFoundError("obstacle not found")
 
-    # normalize boundary z-coordinates to ground elevation when boundary is updated
-    if schema.boundary and schema.boundary.coordinates:
+    # normalize boundary z-coordinates unless coordinator explicitly preserves altitude
+    if schema.boundary and schema.boundary.coordinates and not schema.preserve_altitude:
         _normalize_boundary_altitude(schema.boundary, airport)
 
     apply_schema_update(obstacle, schema)
@@ -463,6 +483,28 @@ def delete_obstacle(db: Session, airport_id: UUID, obstacle_id: UUID):
 
     db.delete(obstacle)
     db.commit()
+
+
+def recalculate_obstacle_dimensions(db: Session, airport_id: UUID, obstacle_id: UUID) -> dict:
+    """compute obstacle dimensions from boundary, returns current + recalculated."""
+    obstacle = (
+        db.query(Obstacle)
+        .filter(Obstacle.id == obstacle_id, Obstacle.airport_id == airport_id)
+        .first()
+    )
+    if not obstacle:
+        raise NotFoundError("obstacle not found")
+
+    recalculated = obstacle.recalculate_dimensions()
+    return {
+        "current": {
+            "length": None,
+            "width": None,
+            "heading": None,
+            "radius": None,
+        },
+        "recalculated": recalculated,
+    }
 
 
 # safety zones
@@ -573,9 +615,9 @@ def update_agl(
     if not agl:
         raise NotFoundError("agl not found")
 
-    # normalize position.z to ground elevation when position is updated
+    # normalize position.z to ground unless coordinator explicitly preserves altitude
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
-    if schema.position and schema.position.coordinates:
+    if schema.position and schema.position.coordinates and not schema.preserve_altitude:
         _normalize_position_altitude(schema.position.coordinates, airport)
 
     apply_schema_update(agl, schema)
@@ -671,9 +713,9 @@ def update_lha(
     if not lha:
         raise NotFoundError("lha not found")
 
-    # normalize position.z to ground elevation when position is updated
+    # normalize position.z to ground unless coordinator explicitly preserves altitude
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
-    if schema.position and schema.position.coordinates:
+    if schema.position and schema.position.coordinates and not schema.preserve_altitude:
         _normalize_position_altitude(schema.position.coordinates, airport)
 
     apply_schema_update(lha, schema)

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -16,7 +16,7 @@ from app.models.enums import MissionStatus
 from app.models.mission import DroneProfile, Mission
 from app.models.value_objects import IcaoCode
 from app.schemas.airport import AirportCreate, AirportSummaryResponse, AirportUpdate
-from app.schemas.geometry import parse_ewkb
+from app.schemas.geometry import PolygonZ, parse_ewkb
 from app.schemas.infrastructure import (
     AGLCreate,
     AGLUpdate,
@@ -408,7 +408,7 @@ def list_obstacles(db: Session, airport_id: UUID) -> list[Obstacle]:
     return db.query(Obstacle).filter(Obstacle.airport_id == airport_id).all()
 
 
-def _normalize_boundary_altitude(boundary: dict | None, airport: Airport) -> None:
+def _normalize_boundary_altitude(boundary: PolygonZ | None, airport: Airport) -> None:
     """set all boundary ring z-coordinates to ground elevation."""
     if not boundary or not boundary.coordinates:
         return

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -330,11 +330,18 @@ def _normalize_position_altitude(position_coords: list[float], airport: Airport)
             provider.close()
 
 
-def renormalize_airport_altitudes(db: Session, airport_id: UUID) -> None:
-    """re-normalize all position.z values for obstacles, agls, and lhas at airport."""
+def renormalize_airport_altitudes(db: Session, airport_id: UUID) -> dict[str, list[UUID]]:
+    """re-normalize all position.z values for obstacles, agls, and lhas at airport.
+
+    returns a dict of skipped entity ids per type so callers can surface partial
+    failures - per-item errors are logged and the loop continues so one bad
+    geometry does not block the rest of the airport.
+    """
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
     if not airport:
         raise NotFoundError("airport not found")
+
+    skipped: dict[str, list[UUID]] = {"obstacles": [], "agls": [], "lhas": []}
 
     provider = create_elevation_provider(airport)
     try:
@@ -371,10 +378,12 @@ def renormalize_airport_altitudes(db: Session, airport_id: UUID) -> None:
                 obs.boundary = WKTElement(f"SRID=4326;POLYGONZ(({wkt_ring}))", srid=4326)
             except Exception as e:
                 logger.warning("skipping renormalization for Obstacle %s: %s", obs.id, e)
+                skipped["obstacles"].append(obs.id)
                 continue
 
         # renormalize AGL and LHA position.z
         for entity in [*agls, *lhas]:
+            bucket = "agls" if isinstance(entity, AGL) else "lhas"
             try:
                 coords = parse_ewkb(entity.position.data).get("coordinates", [])
                 if len(coords) < 3:
@@ -389,9 +398,19 @@ def renormalize_airport_altitudes(db: Session, airport_id: UUID) -> None:
                     entity.id,
                     e,
                 )
+                skipped[bucket].append(entity.id)
                 continue
 
         db.commit()
+
+        if any(skipped.values()):
+            logger.warning(
+                "renormalize_airport_altitudes for %s left partial state: %s",
+                airport_id,
+                {k: len(v) for k, v in skipped.items() if v},
+            )
+
+        return skipped
     finally:
         if hasattr(provider, "close"):
             provider.close()
@@ -490,6 +509,8 @@ def recalculate_obstacle_dimensions(db: Session, airport_id: UUID, obstacle_id: 
         raise NotFoundError("obstacle not found")
 
     recalculated = obstacle.recalculate_dimensions()
+    # obstacles have no stored length/width/heading/radius columns - all dimensions
+    # are derived from the boundary polygon, so "current" is always None
     return {
         "current": {
             "length": None,

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -617,6 +617,8 @@ def update_agl(
 
     # normalize position.z to ground unless coordinator explicitly preserves altitude
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
+    if not airport:
+        raise NotFoundError("airport not found")
     if schema.position and schema.position.coordinates and not schema.preserve_altitude:
         _normalize_position_altitude(schema.position.coordinates, airport)
 
@@ -715,6 +717,8 @@ def update_lha(
 
     # normalize position.z to ground unless coordinator explicitly preserves altitude
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
+    if not airport:
+        raise NotFoundError("airport not found")
     if schema.position and schema.position.coordinates and not schema.preserve_altitude:
         _normalize_position_altitude(schema.position.coordinates, airport)
 
@@ -802,8 +806,6 @@ def get_airport_lonlat(airport: Airport) -> tuple[float, float]:
     """extract lon, lat from airport location geometry."""
     loc = airport.location
     if hasattr(loc, "data"):
-        from app.schemas.geometry import parse_ewkb
-
         parsed = parse_ewkb(loc.data)
         coords = parsed.get("coordinates", [])
         if len(coords) < 2:

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -587,6 +587,8 @@ def create_agl(db: Session, airport_id: UUID, surface_id: UUID, schema: AGLCreat
 
     # normalize position.z to ground elevation at AGL location
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
+    if not airport:
+        raise NotFoundError("airport not found")
     if schema.position and schema.position.coordinates:
         _normalize_position_altitude(schema.position.coordinates, airport)
 
@@ -683,6 +685,8 @@ def create_lha(
 
     # normalize position.z to ground elevation at LHA location
     airport = db.query(Airport).filter(Airport.id == airport_id).first()
+    if not airport:
+        raise NotFoundError("airport not found")
     if schema.position and schema.position.coordinates:
         _normalize_position_altitude(schema.position.coordinates, airport)
 

--- a/backend/app/services/airport_service.py
+++ b/backend/app/services/airport_service.py
@@ -14,7 +14,6 @@ from app.models.agl import AGL, LHA
 from app.models.airport import AirfieldSurface, Airport, Obstacle, SafetyZone
 from app.models.enums import MissionStatus
 from app.models.mission import DroneProfile, Mission
-from app.models.value_objects import IcaoCode
 from app.schemas.airport import AirportCreate, AirportSummaryResponse, AirportUpdate
 from app.schemas.geometry import PolygonZ, parse_ewkb
 from app.schemas.infrastructure import (
@@ -114,12 +113,7 @@ def get_airport(db: Session, airport_id: UUID) -> Airport:
 
 
 def create_airport(db: Session, schema: AirportCreate) -> Airport:
-    """create airport with ICAO code validation."""
-    try:
-        IcaoCode(schema.icao_code)
-    except ValueError as e:
-        raise DomainError(str(e))
-
+    """create airport - icao validation happens at the schema layer."""
     airport = Airport(**schema_to_model_data(schema))
     db.add(airport)
     db.commit()

--- a/backend/app/services/geometry_converter.py
+++ b/backend/app/services/geometry_converter.py
@@ -22,6 +22,9 @@ GEOM_FIELDS = {
 # geometry fields that are NOT NULL in the database - never set these to None
 NON_NULLABLE_GEOM_FIELDS = {"location", "geometry", "boundary"}
 
+# transport-only schema fields that must never be written to the model
+TRANSPORT_ONLY_FIELDS = {"preserve_altitude"}
+
 
 def _fmt_coord(c: list) -> str:
     """format a single coordinate as 'x y z', defaulting z to 0 if missing."""
@@ -58,6 +61,8 @@ def geojson_to_ewkt(geojson: GeoJSON) -> EWKT:
 def schema_to_model_data(schema: BaseModel) -> dict:
     """convert pydantic schema to dict with geometry fields as WKTElement"""
     data = schema.model_dump()
+    for f in TRANSPORT_ONLY_FIELDS:
+        data.pop(f, None)
     for key in GEOM_FIELDS & data.keys():
         if data[key] is not None:
             data[key] = WKTElement(geojson_to_ewkt(data[key]), srid=4326)
@@ -67,7 +72,10 @@ def schema_to_model_data(schema: BaseModel) -> dict:
 
 def apply_schema_update(obj, schema: BaseModel):
     """apply pydantic update schema to ORM model, converting geometry to EWKT"""
-    apply_dict_update(obj, schema.model_dump(exclude_unset=True))
+    data = schema.model_dump(exclude_unset=True)
+    for f in TRANSPORT_ONLY_FIELDS:
+        data.pop(f, None)
+    apply_dict_update(obj, data)
 
 
 def apply_dict_update(obj, data: dict):

--- a/backend/app/services/geometry_converter.py
+++ b/backend/app/services/geometry_converter.py
@@ -19,9 +19,6 @@ GEOM_FIELDS = {
     "boundary",
 }
 
-# geometry fields that are NOT NULL in the database - never set these to None
-NON_NULLABLE_GEOM_FIELDS = {"location", "geometry", "boundary"}
-
 # transport-only schema fields that must never be written to the model
 TRANSPORT_ONLY_FIELDS = {"preserve_altitude"}
 
@@ -79,13 +76,27 @@ def apply_schema_update(obj, schema: BaseModel):
 
 
 def apply_dict_update(obj, data: dict):
-    """apply dict to ORM model, converting geometry fields to WKTElement."""
+    """apply dict to ORM model, converting geometry fields to WKTElement.
+
+    explicit None on a non-nullable geometry column is dropped (treated as
+    'no change') so PATCH-style updates do not have to know which fields
+    are required at the db level.
+    """
+    table = obj.__table__
     for key, val in data.items():
         if key in GEOM_FIELDS:
             if val is not None:
                 setattr(obj, key, WKTElement(geojson_to_ewkt(val), srid=4326))
-            elif key not in NON_NULLABLE_GEOM_FIELDS:
+            elif _is_column_nullable(table, key):
                 setattr(obj, key, None)
-            # skip None for non-nullable geometry fields
+            # else: skip None for non-nullable geometry columns
         else:
             setattr(obj, key, val)
+
+
+def _is_column_nullable(table, key: str) -> bool:
+    """check if an ORM table column is nullable, defaults to True if unknown."""
+    column = table.columns.get(key)
+    if column is None:
+        return True
+    return bool(column.nullable)

--- a/backend/app/utils/geo.py
+++ b/backend/app/utils/geo.py
@@ -75,6 +75,116 @@ def center_of_points(
     )
 
 
+def linestring_length(coords: list[list[float]]) -> float:
+    """sum of great-circle distances along a linestring of (lon, lat, ...) points in meters"""
+    total = 0.0
+    for i in range(1, len(coords)):
+        total += distance_between(coords[i - 1][0], coords[i - 1][1], coords[i][0], coords[i][1])
+
+    return total
+
+
+def polygon_oriented_dimensions(
+    ring: list[list[float]],
+) -> tuple[float, float, float]:
+    """oriented bounding box of a polygon ring (lon, lat, ...).
+
+    returns (length, width, heading_deg) where length is the longest side of
+    the OBB, width is the perpendicular dimension, and heading is the bearing
+    of the long axis. uses rotating calipers on the convex hull and projects
+    points to a local east/north plane centered at the polygon centroid.
+    """
+    pts = list(ring)
+    if len(pts) >= 2 and pts[0] == pts[-1]:
+        pts = pts[:-1]
+    if len(pts) < 3:
+        return 0.0, 0.0, 0.0
+
+    # local east/north projection in meters
+    lat0 = sum(p[1] for p in pts) / len(pts)
+    lon0 = sum(p[0] for p in pts) / len(pts)
+    cos_lat0 = math.cos(math.radians(lat0))
+
+    def to_xy(p):
+        """convert (lon, lat) to local (east, north) meters."""
+        x = math.radians(p[0] - lon0) * EARTH_RADIUS_M * cos_lat0
+        y = math.radians(p[1] - lat0) * EARTH_RADIUS_M
+        return x, y
+
+    xy = [to_xy(p) for p in pts]
+
+    # convex hull (Andrew's monotone chain)
+    xy_sorted = sorted(set(xy))
+    if len(xy_sorted) < 3:
+        return 0.0, 0.0, 0.0
+
+    def cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    lower = []
+    for p in xy_sorted:
+        while len(lower) >= 2 and cross(lower[-2], lower[-1], p) <= 0:
+            lower.pop()
+        lower.append(p)
+    upper = []
+    for p in reversed(xy_sorted):
+        while len(upper) >= 2 and cross(upper[-2], upper[-1], p) <= 0:
+            upper.pop()
+        upper.append(p)
+    hull = lower[:-1] + upper[:-1]
+    if len(hull) < 3:
+        return 0.0, 0.0, 0.0
+
+    # rotating calipers - try each hull edge as the OBB long axis
+    best_area = float("inf")
+    best_length = 0.0
+    best_width = 0.0
+    best_angle = 0.0
+
+    n = len(hull)
+    for i in range(n):
+        x1, y1 = hull[i]
+        x2, y2 = hull[(i + 1) % n]
+        edge_len = math.hypot(x2 - x1, y2 - y1)
+        if edge_len == 0:
+            continue
+        ux, uy = (x2 - x1) / edge_len, (y2 - y1) / edge_len
+        # perpendicular axis
+        vx, vy = -uy, ux
+        min_u = min_v = float("inf")
+        max_u = max_v = float("-inf")
+        for hx, hy in hull:
+            dx, dy = hx - x1, hy - y1
+            u = dx * ux + dy * uy
+            v = dx * vx + dy * vy
+            if u < min_u:
+                min_u = u
+            if u > max_u:
+                max_u = u
+            if v < min_v:
+                min_v = v
+            if v > max_v:
+                max_v = v
+        du = max_u - min_u
+        dv = max_v - min_v
+        area = du * dv
+        if area < best_area:
+            best_area = area
+            length = max(du, dv)
+            width = min(du, dv)
+            # heading aligned with the long side
+            if du >= dv:
+                angle_rad = math.atan2(uy, ux)
+            else:
+                angle_rad = math.atan2(vy, vx)
+            best_length = length
+            best_width = width
+            # convert math angle (CCW from east) to compass bearing (CW from north)
+            best_angle = (90.0 - math.degrees(angle_rad)) % 180.0
+
+    return best_length, best_width, best_angle
+
+
 def total_path_distance(
     points: list[tuple[float, float, float]],
 ) -> float:

--- a/backend/migrations/versions/b5c6d7e8f9a0_polygon_obstacle_buffer_distance.py
+++ b/backend/migrations/versions/b5c6d7e8f9a0_polygon_obstacle_buffer_distance.py
@@ -1,7 +1,7 @@
 """polygon obstacle geometry and buffer distance
 
 Revision ID: b5c6d7e8f9a0
-Revises: f9a0b1c2d3e4
+Revises: b3c4d5e6f7a8
 Create Date: 2026-04-08 10:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from geoalchemy2 import Geometry
 
 
 revision: str = "b5c6d7e8f9a0"
-down_revision: Union[str, None] = "f9a0b1c2d3e4"
+down_revision: Union[str, None] = "b3c4d5e6f7a8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/tests/test_airports.py
+++ b/backend/tests/test_airports.py
@@ -669,6 +669,63 @@ def test_update_agl_preserve_altitude(client):
     assert body["position"]["coordinates"][2] == explicit_alt
 
 
+def test_update_surface_clear_boundary(client):
+    """PUT with boundary=null on a surface clears the polygon (was silently ignored before)."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZBN"},
+    ).json()
+
+    with_boundary = {
+        **SURFACE_PAYLOAD,
+        "boundary": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [14.24, 50.10, 380],
+                    [14.27, 50.10, 380],
+                    [14.27, 50.09, 380],
+                    [14.24, 50.09, 380],
+                    [14.24, 50.10, 380],
+                ]
+            ],
+        },
+    }
+    surface = client.post(f"/api/v1/airports/{apt['id']}/surfaces", json=with_boundary).json()
+    assert surface["boundary"] is not None
+
+    r = client.put(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}",
+        json={"boundary": None},
+    )
+    assert r.status_code == 200
+    assert r.json()["boundary"] is None
+
+
+def test_create_surface_invalid_type_returns_422(client):
+    """invalid surface_type fails at the schema layer with 422, not 500."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZIT"},
+    ).json()
+
+    bad = {**SURFACE_PAYLOAD, "surface_type": "BOGUS"}
+    r = client.post(f"/api/v1/airports/{apt['id']}/surfaces", json=bad)
+    assert r.status_code == 422
+
+
+def test_create_obstacle_invalid_type_returns_422(client):
+    """invalid obstacle type fails at the schema layer with 422, not 500."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZIO"},
+    ).json()
+
+    bad = {**OBSTACLE_PAYLOAD, "type": "BOGUS"}
+    r = client.post(f"/api/v1/airports/{apt['id']}/obstacles", json=bad)
+    assert r.status_code == 422
+
+
 def test_update_lha_preserve_altitude(client):
     """preserve_altitude=True skips position z-normalization on lha update."""
     apt = client.post(

--- a/backend/tests/test_airports.py
+++ b/backend/tests/test_airports.py
@@ -640,3 +640,61 @@ def test_update_obstacle_preserve_altitude(client):
     # the explicit altitude must be preserved (not overwritten by ground elevation)
     for vertex in body["boundary"]["coordinates"][0]:
         assert vertex[2] == explicit_alt
+
+
+def test_update_agl_preserve_altitude(client):
+    """preserve_altitude=True skips position z-normalization on agl update."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZAG"},
+    ).json()
+    surface = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces",
+        json=SURFACE_PAYLOAD,
+    ).json()
+    agl = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/agls",
+        json=AGL_PAYLOAD,
+    ).json()
+
+    explicit_alt = 777.25
+    new_position = {"type": "Point", "coordinates": [14.2745, 50.0972, explicit_alt]}
+
+    r = client.put(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/agls/{agl['id']}",
+        json={"position": new_position, "preserve_altitude": True},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["position"]["coordinates"][2] == explicit_alt
+
+
+def test_update_lha_preserve_altitude(client):
+    """preserve_altitude=True skips position z-normalization on lha update."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZLH"},
+    ).json()
+    surface = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces",
+        json=SURFACE_PAYLOAD,
+    ).json()
+    agl = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/agls",
+        json=AGL_PAYLOAD,
+    ).json()
+    lha = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/agls/{agl['id']}/lhas",
+        json=LHA_PAYLOAD,
+    ).json()
+
+    explicit_alt = 555.75
+    new_position = {"type": "Point", "coordinates": [14.2748, 50.0979, explicit_alt]}
+
+    r = client.put(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/agls/{agl['id']}/lhas/{lha['id']}",
+        json={"position": new_position, "preserve_altitude": True},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["position"]["coordinates"][2] == explicit_alt

--- a/backend/tests/test_airports.py
+++ b/backend/tests/test_airports.py
@@ -530,3 +530,113 @@ def test_bulk_change_drone_nonexistent(client):
         json={"drone_profile_id": str(uuid4())},
     )
     assert r.status_code == 400
+
+
+# recalculate dimensions
+def test_recalculate_surface_dimensions(client):
+    """recompute surface length/heading from centerline geometry."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZRC"},
+    ).json()
+    surface = client.post(
+        f"/api/v1/airports/{apt['id']}/surfaces",
+        json=SURFACE_PAYLOAD,
+    ).json()
+
+    r = client.post(f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}/recalculate")
+    assert r.status_code == 200
+    body = r.json()
+    assert "current" in body
+    assert "recalculated" in body
+    # current should match the seed values
+    assert body["current"]["length"] == 3715.0
+    assert body["current"]["width"] == 45.0
+    assert body["current"]["heading"] == 243.0
+    # recalculated length is great-circle along the linestring (~ 2.5km)
+    assert body["recalculated"]["length"] is not None
+    assert body["recalculated"]["length"] > 0
+    # heading is bearing from start to end of centerline
+    assert body["recalculated"]["heading"] is not None
+
+
+def test_recalculate_surface_404(client):
+    """recalculate returns 404 for unknown surface."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZNF"},
+    ).json()
+
+    r = client.post(f"/api/v1/airports/{apt['id']}/surfaces/{uuid4()}/recalculate")
+    assert r.status_code == 404
+
+
+def test_recalculate_obstacle_dimensions(client):
+    """recompute obstacle dimensions from polygon boundary."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZRO"},
+    ).json()
+    obstacle = client.post(
+        f"/api/v1/airports/{apt['id']}/obstacles",
+        json=OBSTACLE_PAYLOAD,
+    ).json()
+
+    r = client.post(f"/api/v1/airports/{apt['id']}/obstacles/{obstacle['id']}/recalculate")
+    assert r.status_code == 200
+    body = r.json()
+    assert "recalculated" in body
+    rec = body["recalculated"]
+    # rectangular obstacle should yield non-zero length and width
+    assert rec["length"] is not None and rec["length"] > 0
+    assert rec["width"] is not None and rec["width"] > 0
+    # radius is half the smaller axis
+    assert rec["radius"] is not None
+    assert abs(rec["radius"] - rec["width"] / 2) < 1e-6
+
+
+def test_recalculate_obstacle_404(client):
+    """recalculate returns 404 for unknown obstacle."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZNX"},
+    ).json()
+
+    r = client.post(f"/api/v1/airports/{apt['id']}/obstacles/{uuid4()}/recalculate")
+    assert r.status_code == 404
+
+
+def test_update_obstacle_preserve_altitude(client):
+    """preserve_altitude=True skips boundary z-normalization on update."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZPA"},
+    ).json()
+    obstacle = client.post(
+        f"/api/v1/airports/{apt['id']}/obstacles",
+        json=OBSTACLE_PAYLOAD,
+    ).json()
+
+    explicit_alt = 999.5
+    new_boundary = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [14.261, 50.100, explicit_alt],
+                [14.263, 50.100, explicit_alt],
+                [14.263, 50.102, explicit_alt],
+                [14.261, 50.102, explicit_alt],
+                [14.261, 50.100, explicit_alt],
+            ]
+        ],
+    }
+
+    r = client.put(
+        f"/api/v1/airports/{apt['id']}/obstacles/{obstacle['id']}",
+        json={"boundary": new_boundary, "preserve_altitude": True},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # the explicit altitude must be preserved (not overwritten by ground elevation)
+    for vertex in body["boundary"]["coordinates"][0]:
+        assert vertex[2] == explicit_alt

--- a/backend/tests/test_airports.py
+++ b/backend/tests/test_airports.py
@@ -726,6 +726,43 @@ def test_create_obstacle_invalid_type_returns_422(client):
     assert r.status_code == 422
 
 
+def test_negative_buffer_distance_rejected(client):
+    """ge=0 constraint on buffer_distance must reject negatives at the schema layer."""
+    apt = client.post(
+        "/api/v1/airports",
+        json={**AIRPORT_PAYLOAD, "icao_code": "LZBD"},
+    ).json()
+
+    # surface create
+    bad_surface = {**SURFACE_PAYLOAD, "buffer_distance": -1.0}
+    r = client.post(f"/api/v1/airports/{apt['id']}/surfaces", json=bad_surface)
+    assert r.status_code == 422
+
+    # obstacle create
+    bad_obstacle = {**OBSTACLE_PAYLOAD, "buffer_distance": -2.5}
+    r = client.post(f"/api/v1/airports/{apt['id']}/obstacles", json=bad_obstacle)
+    assert r.status_code == 422
+
+    # surface update - need a valid surface first
+    surface = client.post(f"/api/v1/airports/{apt['id']}/surfaces", json=SURFACE_PAYLOAD).json()
+    r = client.put(
+        f"/api/v1/airports/{apt['id']}/surfaces/{surface['id']}",
+        json={"buffer_distance": -3.0},
+    )
+    assert r.status_code == 422
+
+    # mission default_buffer_distance
+    r = client.post(
+        "/api/v1/missions",
+        json={
+            "name": "BadBuffer",
+            "airport_id": apt["id"],
+            "default_buffer_distance": -4.0,
+        },
+    )
+    assert r.status_code == 422
+
+
 def test_update_lha_preserve_altitude(client):
     """preserve_altitude=True skips position z-normalization on lha update."""
     apt = client.post(

--- a/backend/tests/test_geometry_converter.py
+++ b/backend/tests/test_geometry_converter.py
@@ -30,6 +30,29 @@ class FakeUpdateSchema(BaseModel):
     location: Optional[dict] = None
 
 
+class _FakeColumn:
+    """stand-in for a sqlalchemy Column object exposing only `.nullable`."""
+
+    def __init__(self, nullable: bool):
+        """remember nullability flag."""
+        self.nullable = nullable
+
+
+class _FakeTable:
+    """stand-in for `obj.__table__` exposing a `.columns` dict."""
+
+    def __init__(self, columns: dict[str, bool]):
+        """build column map from {name: nullable} dict."""
+        self.columns = {k: _FakeColumn(v) for k, v in columns.items()}
+
+
+def _model(columns: dict[str, bool], **attrs) -> SimpleNamespace:
+    """build a fake ORM-like object with __table__ and initial attrs."""
+    obj = SimpleNamespace(**attrs)
+    obj.__table__ = _FakeTable(columns)
+    return obj
+
+
 class TestGeojsonToEwkt:
     """tests for geojson_to_ewkt conversion."""
 
@@ -104,7 +127,7 @@ class TestApplyDictUpdate:
 
     def test_sets_attributes_with_geometry_conversion(self):
         """geometry fields are converted to EWKT when set on object."""
-        obj = SimpleNamespace()
+        obj = _model({"location": False})
         data = {
             "name": "mission-1",
             "location": {"type": "Point", "coordinates": [16.5, 48.1, 300.0]},
@@ -116,25 +139,31 @@ class TestApplyDictUpdate:
 
     def test_none_non_nullable_geometry_skipped(self):
         """none on non-nullable geometry fields is skipped to protect constraints."""
-        obj = SimpleNamespace(location="existing")
+        obj = _model({"location": False}, location="existing")
         apply_dict_update(obj, {"location": None})
         assert obj.location == "existing"
 
     def test_none_nullable_geometry_set(self):
         """none on nullable geometry fields is applied (e.g. camera_target)."""
-        obj = SimpleNamespace(camera_target="existing")
+        obj = _model({"camera_target": True}, camera_target="existing")
         apply_dict_update(obj, {"camera_target": None})
         assert obj.camera_target is None
 
-    def test_none_boundary_skipped(self):
-        """none on non-nullable boundary field is skipped to protect constraints."""
-        obj = SimpleNamespace(boundary="existing")
+    def test_none_boundary_cleared_when_nullable(self):
+        """nullable boundary (AirfieldSurface) accepts explicit None to clear it."""
+        obj = _model({"boundary": True}, boundary="existing")
+        apply_dict_update(obj, {"boundary": None})
+        assert obj.boundary is None
+
+    def test_none_boundary_skipped_when_non_nullable(self):
+        """non-nullable boundary (Obstacle) silently drops explicit None."""
+        obj = _model({"boundary": False}, boundary="existing")
         apply_dict_update(obj, {"boundary": None})
         assert obj.boundary == "existing"
 
     def test_non_geometry_field_set_directly(self):
         """non-geometry fields are set without conversion."""
-        obj = SimpleNamespace()
+        obj = _model({})
         apply_dict_update(obj, {"status": "DRAFT", "priority": 5})
         assert obj.status == "DRAFT"
         assert obj.priority == 5
@@ -145,7 +174,7 @@ class TestApplySchemaUpdate:
 
     def test_delegates_to_apply_dict_update(self):
         """schema update converts and applies geometry fields to object."""
-        obj = SimpleNamespace(name="old", location="old-ewkt")
+        obj = _model({"location": False}, name="old", location="old-ewkt")
         schema = FakeUpdateSchema(
             name="new",
             location={"type": "Point", "coordinates": [1.0, 2.0, 3.0]},
@@ -157,7 +186,7 @@ class TestApplySchemaUpdate:
 
     def test_excludes_unset_fields(self):
         """only explicitly set fields are applied."""
-        obj = SimpleNamespace(name="original", location="keep-this")
+        obj = _model({"location": False}, name="original", location="keep-this")
         schema = FakeUpdateSchema(name="updated")
         apply_schema_update(obj, schema)
         assert obj.name == "updated"

--- a/frontend/src/api/airports.ts
+++ b/frontend/src/api/airports.ts
@@ -135,14 +135,6 @@ export async function listSurfaces(
   return res.data;
 }
 
-export async function getSurface(
-  airportId: string,
-  id: string,
-): Promise<SurfaceResponse> {
-  const res = await client.get(`/airports/${airportId}/surfaces/${id}`);
-  return res.data;
-}
-
 export async function createSurface(
   airportId: string,
   data: SurfaceCreate,
@@ -184,14 +176,6 @@ export async function listObstacles(
   airportId: string,
 ): Promise<{ data: ObstacleResponse[]; meta: ListMeta }> {
   const res = await client.get(`/airports/${airportId}/obstacles`);
-  return res.data;
-}
-
-export async function getObstacle(
-  airportId: string,
-  id: string,
-): Promise<ObstacleResponse> {
-  const res = await client.get(`/airports/${airportId}/obstacles/${id}`);
   return res.data;
 }
 
@@ -239,14 +223,6 @@ export async function listSafetyZones(
   return res.data;
 }
 
-export async function getSafetyZone(
-  airportId: string,
-  id: string,
-): Promise<SafetyZoneResponse> {
-  const res = await client.get(`/airports/${airportId}/safety-zones/${id}`);
-  return res.data;
-}
-
 export async function createSafetyZone(
   airportId: string,
   data: SafetyZoneCreate,
@@ -283,17 +259,6 @@ export async function listAGLs(
 ): Promise<{ data: AGLResponse[]; meta: ListMeta }> {
   const res = await client.get(
     `/airports/${airportId}/surfaces/${surfaceId}/agls`,
-  );
-  return res.data;
-}
-
-export async function getAGL(
-  airportId: string,
-  surfaceId: string,
-  id: string,
-): Promise<AGLResponse> {
-  const res = await client.get(
-    `/airports/${airportId}/surfaces/${surfaceId}/agls/${id}`,
   );
   return res.data;
 }
@@ -343,18 +308,6 @@ export async function listLHAs(
 ): Promise<{ data: LHAResponse[]; meta: ListMeta }> {
   const res = await client.get(
     `/airports/${airportId}/surfaces/${surfaceId}/agls/${aglId}/lhas`,
-  );
-  return res.data;
-}
-
-export async function getLHA(
-  airportId: string,
-  surfaceId: string,
-  aglId: string,
-  id: string,
-): Promise<LHAResponse> {
-  const res = await client.get(
-    `/airports/${airportId}/surfaces/${surfaceId}/agls/${aglId}/lhas/${id}`,
   );
   return res.data;
 }

--- a/frontend/src/api/airports.ts
+++ b/frontend/src/api/airports.ts
@@ -9,9 +9,11 @@ import type {
   SurfaceResponse,
   SurfaceCreate,
   SurfaceUpdate,
+  SurfaceRecalculateResponse,
   ObstacleResponse,
   ObstacleCreate,
   ObstacleUpdate,
+  ObstacleRecalculateResponse,
   SafetyZoneResponse,
   SafetyZoneCreate,
   SafetyZoneUpdate,
@@ -166,6 +168,16 @@ export async function deleteSurface(
   return res.data;
 }
 
+export async function recalculateSurface(
+  airportId: string,
+  id: string,
+): Promise<SurfaceRecalculateResponse> {
+  const res = await client.post(
+    `/airports/${airportId}/surfaces/${id}/recalculate`,
+  );
+  return res.data;
+}
+
 // obstacles
 
 export async function listObstacles(
@@ -205,6 +217,16 @@ export async function deleteObstacle(
   id: string,
 ): Promise<DeleteResponse> {
   const res = await client.delete(`/airports/${airportId}/obstacles/${id}`);
+  return res.data;
+}
+
+export async function recalculateObstacle(
+  airportId: string,
+  id: string,
+): Promise<ObstacleRecalculateResponse> {
+  const res = await client.post(
+    `/airports/${airportId}/obstacles/${id}/recalculate`,
+  );
   return res.data;
 }
 

--- a/frontend/src/components/coordinator/ConfirmDeleteDialog.tsx
+++ b/frontend/src/components/coordinator/ConfirmDeleteDialog.tsx
@@ -6,6 +6,7 @@ interface ConfirmDeleteDialogProps {
   isOpen: boolean;
   name: string;
   warnings?: string[];
+  error?: string | null;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -14,6 +15,7 @@ export default function ConfirmDeleteDialog({
   isOpen,
   name,
   warnings,
+  error,
   onConfirm,
   onCancel,
 }: ConfirmDeleteDialogProps) {
@@ -35,6 +37,14 @@ export default function ConfirmDeleteDialog({
               <li key={i}>{w}</li>
             ))}
           </ul>
+        </div>
+      )}
+      {error && (
+        <div
+          className="mb-4 rounded-xl border border-tv-error px-3 py-2"
+          data-testid="delete-error"
+        >
+          <p className="text-xs text-tv-error">{error}</p>
         </div>
       )}
       <div className="flex justify-end gap-2">

--- a/frontend/src/components/coordinator/CoordinatorAGLPanel.tsx
+++ b/frontend/src/components/coordinator/CoordinatorAGLPanel.tsx
@@ -9,7 +9,7 @@ import type { MapFeature } from "@/types/map";
 interface CoordinatorAGLPanelProps {
   surfaces: SurfaceResponse[];
   onItemClick: (feature: MapFeature) => void;
-  onDeleteAgl: (id: string) => void;
+  onDeleteAgl: (id: string) => Promise<void>;
   onAdd?: () => void;
 }
 
@@ -24,6 +24,7 @@ export default function CoordinatorAGLPanel({
   const [collapsed, setCollapsed] = useState(false);
   const [expandedAgls, setExpandedAgls] = useState<Set<string>>(new Set());
   const [deleteTarget, setDeleteTarget] = useState<AGLResponse | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const allAgls = surfaces.flatMap((s) => s.agls);
   const count = allAgls.length;
@@ -208,13 +209,25 @@ export default function CoordinatorAGLPanel({
       <ConfirmDeleteDialog
         isOpen={deleteTarget !== null}
         name={deleteTarget?.name ?? ""}
-        onConfirm={() => {
-          if (deleteTarget) {
-            onDeleteAgl(deleteTarget.id);
+        error={deleteError}
+        onConfirm={async () => {
+          if (!deleteTarget) return;
+          setDeleteError(null);
+          try {
+            await onDeleteAgl(deleteTarget.id);
             setDeleteTarget(null);
+          } catch (err) {
+            setDeleteError(
+              err instanceof Error && err.message
+                ? err.message
+                : t("coordinator.detail.deleteError"),
+            );
           }
         }}
-        onCancel={() => setDeleteTarget(null)}
+        onCancel={() => {
+          setDeleteError(null);
+          setDeleteTarget(null);
+        }}
       />
     </>
   );

--- a/frontend/src/components/coordinator/CoordinatorAGLPanel.tsx
+++ b/frontend/src/components/coordinator/CoordinatorAGLPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronRight, ChevronUp, Trash2, Plus } from "lucide-react";
 import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
+import { formatAglDisplayName } from "@/utils/agl";
 import type { AGLResponse, LHAResponse, SurfaceResponse } from "@/types/airport";
 import type { MapFeature } from "@/types/map";
 
@@ -26,6 +27,10 @@ export default function CoordinatorAGLPanel({
 
   const allAgls = surfaces.flatMap((s) => s.agls);
   const count = allAgls.length;
+  const surfaceByAglId: Record<string, SurfaceResponse> = {};
+  for (const s of surfaces) {
+    for (const a of s.agls) surfaceByAglId[a.id] = s;
+  }
 
   function toggleExpand(aglId: string) {
     /** toggle expand/collapse state for an agl item. */
@@ -124,7 +129,7 @@ export default function CoordinatorAGLPanel({
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <span className="text-xs font-medium text-tv-text-primary truncate">
-                            {agl.name}
+                            {formatAglDisplayName(agl, surfaceByAglId[agl.id])}
                           </span>
                           <span
                             className="rounded-full px-1.5 py-0.5 text-[10px] font-medium border"

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -69,8 +69,13 @@ export default function EditableFeatureInfo({
         const data = await recalculateObstacle(airportId, String(formData.id));
         setRecalcPreview({ kind: "obstacle", data });
       }
-    } catch {
-      setRecalcError(t("coordinator.detail.recalculateError"));
+    } catch (err) {
+      console.error("recalculate failed", err);
+      setRecalcError(
+        err instanceof Error && err.message
+          ? err.message
+          : t("coordinator.detail.recalculateError"),
+      );
     } finally {
       setRecalcLoading(false);
     }

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -196,6 +196,13 @@ export default function EditableFeatureInfo({
                 onChange={(e) => handleChange("width", e.target.value === "" ? null : parseFloat(e.target.value))}
               />
             </div>
+            <Input
+              id="feat-surface-buffer"
+              label={t("coordinator.detail.bufferDistance")}
+              type="number"
+              value={val("buffer_distance")}
+              onChange={(e) => handleChange("buffer_distance", e.target.value === "" ? null : parseFloat(e.target.value))}
+            />
             {airportId && (
               <RecalculateBlock
                 loading={recalcLoading}

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -1,26 +1,38 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Trash2, RotateCcw, Plus } from "lucide-react";
+import { Trash2, RotateCcw, Plus, Calculator } from "lucide-react";
 import Input from "@/components/common/Input";
 import FeatureInfoPanel from "@/components/common/FeatureInfoPanel";
 import ConfirmDeleteDialog from "./ConfirmDeleteDialog";
 import type { MapFeature } from "@/types/map";
-import type { SurfaceResponse } from "@/types/airport";
+import type {
+  SurfaceResponse,
+  SurfaceRecalculateResponse,
+  ObstacleRecalculateResponse,
+} from "@/types/airport";
+import type { PointZ } from "@/types/common";
+import { recalculateSurface, recalculateObstacle } from "@/api/airports";
 
 interface EditableFeatureInfoProps {
   feature: MapFeature;
   onUpdate: (data: Record<string, unknown>) => void;
   onClose: () => void;
+  airportId?: string;
   surfaces?: SurfaceResponse[];
   onDelete?: (featureType: string, id: string) => void;
   deleteWarnings?: string[];
   onAddLha?: (aglId: string) => void;
 }
 
+type RecalcPreview =
+  | { kind: "surface"; data: SurfaceRecalculateResponse }
+  | { kind: "obstacle"; data: ObstacleRecalculateResponse };
+
 export default function EditableFeatureInfo({
   feature,
   onUpdate,
   onClose,
+  airportId,
   surfaces,
   onDelete,
   deleteWarnings,
@@ -32,10 +44,50 @@ export default function EditableFeatureInfo({
     feature.data as unknown as Record<string, unknown>,
   );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [recalcPreview, setRecalcPreview] = useState<RecalcPreview | null>(null);
+  const [recalcLoading, setRecalcLoading] = useState(false);
+  const [recalcError, setRecalcError] = useState<string | null>(null);
 
   useEffect(() => {
     setFormData(feature.data as unknown as Record<string, unknown>);
+    setRecalcPreview(null);
+    setRecalcError(null);
   }, [feature]);
+
+  async function handleRecalculate() {
+    /** call backend to recompute dimensions and show side-by-side preview. */
+    if (!airportId) return;
+    setRecalcLoading(true);
+    setRecalcError(null);
+    try {
+      if (feature.type === "surface") {
+        const data = await recalculateSurface(airportId, String(formData.id));
+        setRecalcPreview({ kind: "surface", data });
+      } else if (feature.type === "obstacle") {
+        const data = await recalculateObstacle(airportId, String(formData.id));
+        setRecalcPreview({ kind: "obstacle", data });
+      }
+    } catch {
+      setRecalcError(t("coordinator.detail.recalculateError"));
+    } finally {
+      setRecalcLoading(false);
+    }
+  }
+
+  function handleApplyRecalculate() {
+    /** apply recalculated dimensions via the standard update path. */
+    if (!recalcPreview) return;
+    const recalculated = recalcPreview.data.recalculated;
+    const updates: Record<string, unknown> = {};
+    if (recalcPreview.kind === "surface") {
+      if (recalculated.length != null) updates.length = recalculated.length;
+      if (recalculated.width != null) updates.width = recalculated.width;
+      if (recalculated.heading != null) updates.heading = recalculated.heading;
+    }
+    setFormData((prev) => ({ ...prev, ...updates }));
+    onUpdate(updates);
+    setRecalcPreview(null);
+  }
 
   function val(key: string): string {
     /** get form field value as string for input binding. */
@@ -131,6 +183,16 @@ export default function EditableFeatureInfo({
                 onChange={(e) => handleChange("width", e.target.value === "" ? null : parseFloat(e.target.value))}
               />
             </div>
+            {airportId && (
+              <RecalculateBlock
+                loading={recalcLoading}
+                error={recalcError}
+                preview={recalcPreview}
+                onRecalculate={handleRecalculate}
+                onApply={handleApplyRecalculate}
+                onCancel={() => setRecalcPreview(null)}
+              />
+            )}
           </>
         )}
 
@@ -174,6 +236,16 @@ export default function EditableFeatureInfo({
                 onChange={(e) => handleChange("buffer_distance", e.target.value === "" ? null : parseFloat(e.target.value))}
               />
             </div>
+            {airportId && (
+              <RecalculateBlock
+                loading={recalcLoading}
+                error={recalcError}
+                preview={recalcPreview}
+                onRecalculate={handleRecalculate}
+                onApply={handleApplyRecalculate}
+                onCancel={() => setRecalcPreview(null)}
+              />
+            )}
           </>
         )}
 
@@ -283,6 +355,14 @@ export default function EditableFeatureInfo({
               value={val("glide_slope_angle")}
               onChange={(e) => handleChange("glide_slope_angle", e.target.value === "" ? null : parseFloat(e.target.value))}
             />
+            <PointCoordEditor
+              position={(formData.position as PointZ | undefined) ?? null}
+              onChange={(coords) => {
+                const newPos = { type: "Point" as const, coordinates: coords };
+                setFormData((prev) => ({ ...prev, position: newPos }));
+                onUpdate({ position: newPos, preserve_altitude: true });
+              }}
+            />
             {onAddLha && (
               <button
                 onClick={() => onAddLha(String(formData.id))}
@@ -326,6 +406,14 @@ export default function EditableFeatureInfo({
                 <option value="LED">{t("coordinator.detail.lampTypes.led")}</option>
               </select>
             </div>
+            <PointCoordEditor
+              position={(formData.position as PointZ | undefined) ?? null}
+              onChange={(coords) => {
+                const newPos = { type: "Point" as const, coordinates: coords };
+                setFormData((prev) => ({ ...prev, position: newPos }));
+                onUpdate({ position: newPos, preserve_altitude: true });
+              }}
+            />
           </>
         )}
 
@@ -360,6 +448,160 @@ export default function EditableFeatureInfo({
           onCancel={() => setShowDeleteConfirm(false)}
         />
       )}
+    </div>
+  );
+}
+
+function PointCoordEditor({
+  position,
+  onChange,
+}: {
+  position: PointZ | null;
+  onChange: (coords: [number, number, number]) => void;
+}) {
+  /** inline lat/lon/alt editor for a point geometry. */
+  const { t } = useTranslation();
+  if (!position || position.coordinates.length < 3) return null;
+  const [lon, lat, alt] = position.coordinates;
+
+  function commit(field: "lat" | "lon" | "alt", value: string) {
+    /** parse + validate, then push update via onChange. */
+    const v = parseFloat(value);
+    if (isNaN(v)) return;
+    if (field === "lat" && (v < -90 || v > 90)) return;
+    if (field === "lon" && (v < -180 || v > 180)) return;
+    if (field === "alt" && v < 0) return;
+    const newLat = field === "lat" ? v : lat;
+    const newLon = field === "lon" ? v : lon;
+    const newAlt = field === "alt" ? v : alt;
+    onChange([newLon, newLat, newAlt]);
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-1.5" data-testid="point-coord-editor">
+      <Input
+        id="feat-lat"
+        label={t("map.coordinates.lat")}
+        type="number"
+        step="0.000001"
+        value={String(lat)}
+        onChange={(e) => commit("lat", e.target.value)}
+      />
+      <Input
+        id="feat-lon"
+        label={t("map.coordinates.lon")}
+        type="number"
+        step="0.000001"
+        value={String(lon)}
+        onChange={(e) => commit("lon", e.target.value)}
+      />
+      <Input
+        id="feat-alt"
+        label={t("map.coordinates.alt")}
+        type="number"
+        step="0.01"
+        value={String(alt)}
+        onChange={(e) => commit("alt", e.target.value)}
+      />
+    </div>
+  );
+}
+
+function fmtDim(v: number | null | undefined, unit: string) {
+  /** format a dimension number with unit, dash if missing. */
+  if (v == null) return "—";
+  return `${v.toFixed(2)}${unit}`;
+}
+
+function RecalculateBlock({
+  loading,
+  error,
+  preview,
+  onRecalculate,
+  onApply,
+  onCancel,
+}: {
+  loading: boolean;
+  error: string | null;
+  preview: RecalcPreview | null;
+  onRecalculate: () => void;
+  onApply: () => void;
+  onCancel: () => void;
+}) {
+  /** recalculate dimensions button + side-by-side preview. */
+  const { t } = useTranslation();
+
+  if (preview) {
+    const { current, recalculated } = preview.data;
+    const m = t("common.units.m");
+    return (
+      <div
+        className="mt-2 rounded-lg border border-tv-border bg-tv-bg p-2 space-y-1.5"
+        data-testid="recalculate-preview"
+      >
+        <div className="grid grid-cols-3 gap-1 text-[10px] text-tv-text-muted">
+          <span></span>
+          <span className="text-right">{t("coordinator.detail.currentValues")}</span>
+          <span className="text-right">{t("coordinator.detail.recalculatedValues")}</span>
+        </div>
+        <div className="grid grid-cols-3 gap-1 text-xs">
+          <span className="text-tv-text-muted">{t("coordinator.detail.surfaceLength")}</span>
+          <span className="text-right text-tv-text-secondary">{fmtDim(current.length, m)}</span>
+          <span className="text-right text-tv-text-primary font-medium">
+            {fmtDim(recalculated.length, m)}
+          </span>
+        </div>
+        <div className="grid grid-cols-3 gap-1 text-xs">
+          <span className="text-tv-text-muted">{t("coordinator.detail.surfaceWidth")}</span>
+          <span className="text-right text-tv-text-secondary">{fmtDim(current.width, m)}</span>
+          <span className="text-right text-tv-text-primary font-medium">
+            {fmtDim(recalculated.width, m)}
+          </span>
+        </div>
+        {preview.kind === "surface" && (
+          <div className="grid grid-cols-3 gap-1 text-xs">
+            <span className="text-tv-text-muted">{t("coordinator.detail.surfaceHeading")}</span>
+            <span className="text-right text-tv-text-secondary">
+              {fmtDim(preview.data.current.heading, "°")}
+            </span>
+            <span className="text-right text-tv-text-primary font-medium">
+              {fmtDim(preview.data.recalculated.heading, "°")}
+            </span>
+          </div>
+        )}
+        <div className="flex gap-1.5 pt-1">
+          <button
+            onClick={onApply}
+            className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-accent text-tv-accent hover:bg-tv-surface-hover transition-colors"
+            data-testid="recalculate-apply"
+          >
+            {t("coordinator.detail.applyRecalculated")}
+          </button>
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-border text-tv-text-primary hover:bg-tv-surface-hover transition-colors"
+            data-testid="recalculate-cancel"
+          >
+            {t("coordinator.detail.cancelRecalculated")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <button
+        onClick={onRecalculate}
+        disabled={loading}
+        title={t("coordinator.detail.recalculateDescription")}
+        className="flex items-center justify-center gap-1.5 w-full mt-1 px-3 py-1.5 rounded-full text-xs font-semibold border border-tv-border text-tv-text-primary hover:bg-tv-surface-hover transition-colors disabled:opacity-50"
+        data-testid="recalculate-button"
+      >
+        <Calculator className="h-3 w-3" />
+        {t("coordinator.detail.recalculate")}
+      </button>
+      {error && <p className="text-[10px] text-tv-error pl-1">{error}</p>}
     </div>
   );
 }

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -44,6 +44,7 @@ export default function EditableFeatureInfo({
     feature.data as unknown as Record<string, unknown>,
   );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [recalcPreview, setRecalcPreview] = useState<RecalcPreview | null>(null);
   const [recalcLoading, setRecalcLoading] = useState(false);
   const [recalcError, setRecalcError] = useState<string | null>(null);
@@ -52,6 +53,7 @@ export default function EditableFeatureInfo({
     setFormData(feature.data as unknown as Record<string, unknown>);
     setRecalcPreview(null);
     setRecalcError(null);
+    setDeleteError(null);
   }, [feature]);
 
   async function handleRecalculate() {
@@ -77,13 +79,16 @@ export default function EditableFeatureInfo({
   function handleApplyRecalculate() {
     /** apply recalculated dimensions via the standard update path. */
     if (!recalcPreview) return;
+    // obstacle preview is read-only - obstacles have no length/width columns
+    if (recalcPreview.kind !== "surface") {
+      setRecalcPreview(null);
+      return;
+    }
     const recalculated = recalcPreview.data.recalculated;
     const updates: Record<string, unknown> = {};
-    if (recalcPreview.kind === "surface") {
-      if (recalculated.length != null) updates.length = recalculated.length;
-      if (recalculated.width != null) updates.width = recalculated.width;
-      if (recalculated.heading != null) updates.heading = recalculated.heading;
-    }
+    if (recalculated.length != null) updates.length = recalculated.length;
+    if (recalculated.width != null) updates.width = recalculated.width;
+    if (recalculated.heading != null) updates.heading = recalculated.heading;
     setFormData((prev) => ({ ...prev, ...updates }));
     onUpdate(updates);
     setRecalcPreview(null);
@@ -436,16 +441,25 @@ export default function EditableFeatureInfo({
           isOpen={showDeleteConfirm}
           name={val("name") || val("identifier") || val("unit_number") || ""}
           warnings={deleteWarnings}
+          error={deleteError}
           onConfirm={async () => {
+            setDeleteError(null);
             try {
-              setShowDeleteConfirm(false);
               await onDelete(feature.type, String(formData.id));
-              onClose();
-            } catch {
               setShowDeleteConfirm(false);
+              onClose();
+            } catch (err) {
+              setDeleteError(
+                err instanceof Error && err.message
+                  ? err.message
+                  : t("coordinator.detail.deleteError"),
+              );
             }
           }}
-          onCancel={() => setShowDeleteConfirm(false)}
+          onCancel={() => {
+            setDeleteError(null);
+            setShowDeleteConfirm(false);
+          }}
         />
       )}
     </div>
@@ -570,20 +584,33 @@ function RecalculateBlock({
           </div>
         )}
         <div className="flex gap-1.5 pt-1">
-          <button
-            onClick={onApply}
-            className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-accent text-tv-accent hover:bg-tv-surface-hover transition-colors"
-            data-testid="recalculate-apply"
-          >
-            {t("coordinator.detail.applyRecalculated")}
-          </button>
-          <button
-            onClick={onCancel}
-            className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-border text-tv-text-primary hover:bg-tv-surface-hover transition-colors"
-            data-testid="recalculate-cancel"
-          >
-            {t("coordinator.detail.cancelRecalculated")}
-          </button>
+          {preview.kind === "surface" ? (
+            <>
+              <button
+                onClick={onApply}
+                className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-accent text-tv-accent hover:bg-tv-surface-hover transition-colors"
+                data-testid="recalculate-apply"
+              >
+                {t("coordinator.detail.applyRecalculated")}
+              </button>
+              <button
+                onClick={onCancel}
+                className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-border text-tv-text-primary hover:bg-tv-surface-hover transition-colors"
+                data-testid="recalculate-cancel"
+              >
+                {t("coordinator.detail.cancelRecalculated")}
+              </button>
+            </>
+          ) : (
+            // obstacle preview is informational only - no writable dimension columns
+            <button
+              onClick={onCancel}
+              className="flex-1 rounded-full px-3 py-1.5 text-xs font-semibold border border-tv-border text-tv-text-primary hover:bg-tv-surface-hover transition-colors"
+              data-testid="recalculate-close"
+            >
+              {t("common.close")}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -19,7 +19,7 @@ interface EditableFeatureInfoProps {
   onClose: () => void;
   airportId?: string;
   surfaces?: SurfaceResponse[];
-  onDelete?: (featureType: string, id: string) => void;
+  onDelete?: (featureType: string, id: string) => Promise<void>;
   deleteWarnings?: string[];
   onAddLha?: (aglId: string) => void;
 }

--- a/frontend/src/components/coordinator/EditableFeatureInfo.tsx
+++ b/frontend/src/components/coordinator/EditableFeatureInfo.tsx
@@ -40,9 +40,12 @@ export default function EditableFeatureInfo({
 }: EditableFeatureInfoProps) {
   /** editable feature info panel for selected map features. */
   const { t } = useTranslation();
-  const [formData, setFormData] = useState<Record<string, unknown>>(
-    feature.data as unknown as Record<string, unknown>,
-  );
+  // form state is intentionally loose - it collects partial edits that get
+  // pushed to onUpdate, but the source data is always one of the typed
+  // response shapes from MapFeature
+  const [formData, setFormData] = useState<Record<string, unknown>>(() => ({
+    ...feature.data,
+  }));
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [recalcPreview, setRecalcPreview] = useState<RecalcPreview | null>(null);
@@ -50,7 +53,7 @@ export default function EditableFeatureInfo({
   const [recalcError, setRecalcError] = useState<string | null>(null);
 
   useEffect(() => {
-    setFormData(feature.data as unknown as Record<string, unknown>);
+    setFormData({ ...feature.data });
     setRecalcPreview(null);
     setRecalcError(null);
     setDeleteError(null);
@@ -489,7 +492,7 @@ function PointCoordEditor({
     if (isNaN(v)) return;
     if (field === "lat" && (v < -90 || v > 90)) return;
     if (field === "lon" && (v < -180 || v > 180)) return;
-    if (field === "alt" && v < 0) return;
+    // altitude is MSL, can be negative for sub-sea-level airports
     const newLat = field === "lat" ? v : lat;
     const newLon = field === "lon" ? v : lon;
     const newAlt = field === "alt" ? v : alt;

--- a/frontend/src/components/map/AirportMap.tsx
+++ b/frontend/src/components/map/AirportMap.tsx
@@ -1156,6 +1156,23 @@ const AirportMap = forwardRef<AirportMapHandle, AirportMapProps & {
       addHighlightLayers(map);
       addPendingPreviewLayers(map);
       layersAddedRef.current = true;
+
+      // sync layer visibility immediately so newly-added layers honor the
+      // current LayerPanel toggle state instead of defaulting to "visible"
+      const cfg = layerConfigRef.current;
+      for (const [key, layerIds] of Object.entries(layerGroupMap)) {
+        const visible = cfg[key as keyof MapLayerConfig];
+        if (visible === undefined) continue;
+        for (const layerId of layerIds) {
+          try {
+            if (map.getLayer(layerId)) {
+              map.setLayoutProperty(layerId, "visibility", visible ? "visible" : "none");
+            }
+          } catch {
+            // layer may not exist
+          }
+        }
+      }
     },
     [airport],
   );
@@ -1281,6 +1298,8 @@ const AirportMap = forwardRef<AirportMapHandle, AirportMapProps & {
   // add or update waypoint layers
   const addWaypointLayers = useCallback((map: maplibregl.Map, wpsOverride?: WaypointResponse[]) => {
     const wps = wpsOverride ?? waypointsRef.current;
+    // keep ref in sync so other code paths see the same data
+    waypointsRef.current = wps;
     const takeoff = takeoffRef.current;
     const landing = landingRef.current;
     const idxMap = indexMapRef.current;
@@ -1300,6 +1319,12 @@ const AirportMap = forwardRef<AirportMapHandle, AirportMapProps & {
       highlightSeverityRef.current,
       layerConfigRef.current.simplifiedTrajectory,
     );
+
+    // force maplibre to render the updated source data on the next frame
+    // - GeoJSONSource.setData is queued internally and may not redraw until
+    //   the next user interaction; triggerRepaint guarantees immediate paint
+    //   so newly-inserted transit waypoints appear without an extra click.
+    map.triggerRepaint();
   }, [selectedWaypointId, syncLayerVisibility, syncInspectionFilters]);
 
   // sync waypoints ref and re-render layers when waypoints or coords change
@@ -1848,6 +1873,28 @@ const AirportMap = forwardRef<AirportMapHandle, AirportMapProps & {
     }
   }, [layerConfig]);
 
+  // mount-time guard - poll until the style is loaded then sync visibility once
+  // so the LayerPanel toggle state matches actual MapLibre layer visibility
+  // regardless of which layer-add path created the layers first.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    let cancelled = false;
+    function trySync() {
+      if (cancelled || !map) return;
+      if (!map.isStyleLoaded()) {
+        requestAnimationFrame(trySync);
+        return;
+      }
+      syncLayerVisibility(map);
+    }
+    trySync();
+    return () => {
+      cancelled = true;
+    };
+  }, [airport, syncLayerVisibility]);
+
   // sync inspection visibility filters
   useEffect(() => {
     const map = mapRef.current;
@@ -2134,6 +2181,7 @@ const AirportMap = forwardRef<AirportMapHandle, AirportMapProps & {
             <PoiInfoPanel
               feature={selectedFeature}
               onClose={() => setSelectedFeature(null)}
+              surfaces={airport.surfaces}
             />
           )}
           {selectedWarning && onWarningClose && (

--- a/frontend/src/components/map/overlays/PoiInfoPanel.tsx
+++ b/frontend/src/components/map/overlays/PoiInfoPanel.tsx
@@ -2,13 +2,16 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import FeatureInfoPanel from "@/components/common/FeatureInfoPanel";
 import { ChevronDown } from "lucide-react";
+import { formatAglDisplayName } from "@/utils/agl";
 import type { MapFeature } from "@/types/map";
 import type { PointZ, PolygonZ } from "@/types/common";
+import type { SurfaceResponse } from "@/types/airport";
 
 interface PoiInfoPanelProps {
   feature: MapFeature | null;
   onClose: () => void;
   editable?: boolean;
+  surfaces?: SurfaceResponse[];
   onCoordinateChange?: (waypointId: string, lat: number, lon: number, alt: number) => void;
   onDeleteTakeoffLanding?: (waypointType: string) => void;
 }
@@ -17,6 +20,7 @@ export default function PoiInfoPanel({
   feature,
   onClose,
   editable = false,
+  surfaces,
   onCoordinateChange,
   onDeleteTakeoffLanding,
 }: PoiInfoPanelProps) {
@@ -80,9 +84,10 @@ export default function PoiInfoPanel({
       }
       case "agl": {
         const a = feature.data;
+        const parentSurface = surfaces?.find((s) => s.id === a.surface_id);
         return (
           <>
-            <InfoRow label={t("dashboard.poiName")} value={a.name} />
+            <InfoRow label={t("dashboard.poiName")} value={formatAglDisplayName(a, parentSurface)} />
             <InfoRow label={t("dashboard.poiType")} value={a.agl_type} />
             {a.side && <InfoRow label={t("dashboard.poiSide")} value={a.side} />}
             <CoordRows position={a.position} label={t("dashboard.poiCoordinates")} />
@@ -224,21 +229,27 @@ function CoordRows({ position, label }: { position: PointZ; label: string }) {
           <span className="text-tv-text-muted">{t("map.coordinates.lon")}</span>
           <span className="text-tv-text-primary font-medium">{lon.toFixed(6)}</span>
         </div>
-        {alt != null && alt !== 0 && (
-          <div className="flex justify-between">
-            <span className="text-tv-text-muted">{t("map.coordinates.alt")}</span>
-            <span className="text-tv-text-primary font-medium">{alt.toFixed(1)}{t("common.units.m")}</span>
-          </div>
-        )}
+        <div className="flex justify-between">
+          <span className="text-tv-text-muted">{t("map.coordinates.alt")}</span>
+          <span className="text-tv-text-primary font-medium">{(alt ?? 0).toFixed(2)}{t("common.units.m")}</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function PolygonCoordRows({ polygon, label }: { polygon: PolygonZ; label: string }) {
-  /** polygon centroid + expandable vertex list. */
+function PolygonCoordRows({
+  polygon,
+  label,
+  defaultExpanded = false,
+}: {
+  polygon: PolygonZ;
+  label: string;
+  defaultExpanded?: boolean;
+}) {
+  /** polygon centroid + expandable vertex list with altitude. */
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const ring = polygon.coordinates[0];
   if (!ring || ring.length < 3) return null;
 
@@ -272,12 +283,12 @@ function PolygonCoordRows({ polygon, label }: { polygon: PolygonZ; label: string
         <span>{t("map.vertices")} ({vertices.length})</span>
       </button>
       {expanded && (
-        <div className="pl-2 mt-0.5 space-y-1 max-h-32 overflow-y-auto">
+        <div className="pl-2 mt-0.5 space-y-1 max-h-40 overflow-y-auto">
           {vertices.map((v, i) => (
             <div key={i} className="flex justify-between gap-2">
               <span className="text-tv-text-muted">#{i + 1}</span>
-              <span className="text-tv-text-primary font-medium">
-                {v[1].toFixed(6)}, {v[0].toFixed(6)}
+              <span className="text-tv-text-primary font-medium tabular-nums text-right">
+                {v[1].toFixed(6)}, {v[0].toFixed(6)}, {(v[2] ?? 0).toFixed(2)}{t("common.units.m")}
               </span>
             </div>
           ))}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -742,6 +742,18 @@
       "lhaUnitNumber": "Unit Number",
       "lhaSettingAngle": "Setting Angle",
       "lhaLampType": "Lamp Type",
+      "recalculate": "Recalculate Dimensions",
+      "recalculateDescription": "Recompute length, width, and heading from polygon geometry",
+      "currentValues": "Current",
+      "recalculatedValues": "Recalculated",
+      "applyRecalculated": "Apply",
+      "cancelRecalculated": "Cancel",
+      "recalculateError": "Failed to recalculate dimensions",
+      "vertexCoord": "Vertices",
+      "vertexEdit": "Edit vertex",
+      "latInvalid": "Latitude must be between -90 and 90",
+      "lonInvalid": "Longitude must be between -180 and 180",
+      "altInvalid": "Altitude must be ≥ 0",
       "surfaceTypes": {
         "runway": "Runway",
         "taxiway": "Taxiway",
@@ -769,6 +781,9 @@
         "halogen": "Halogen",
         "led": "LED"
       }
+    },
+    "agl": {
+      "displayNameFormat": "PAPI RWY {{runway}}"
     },
     "tools": {
       "select": "Select",

--- a/frontend/src/pages/coordinator-center/AirportEditPage.tsx
+++ b/frontend/src/pages/coordinator-center/AirportEditPage.tsx
@@ -240,12 +240,11 @@ export default function AirportEditPage() {
   const handleVertexGeometryUpdate = useCallback(
     (featureType: string, featureId: string, update: VertexGeometryUpdate) => {
       /** handle geometry update from vertex editor - mark dirty and update map preview. */
-      // only include api-safe fields in dirty data (exclude `polygon` which is preview-only)
+      // only persist geometry + boundary from vertex drags. length/width/heading
+      // are user-facing metadata and should not get silently overwritten - use
+      // the "recalculate dimensions" button to sync them from geometry on demand.
       const dirtyData: Record<string, unknown> = { geometry: update.geometry };
       if (update.boundary) dirtyData.boundary = update.boundary;
-      if (update.width != null) dirtyData.width = update.width;
-      if (update.length != null) dirtyData.length = update.length;
-      if (update.heading != null) dirtyData.heading = update.heading;
       markDirty(featureType, featureId, "update", dirtyData);
 
       // live preview: update map source so the shape moves with the vertices
@@ -385,19 +384,29 @@ export default function AirportEditPage() {
             drawnWidth = (d01 + haversineDistance(pts[2][0], pts[2][1], pts[3][0], pts[3][1])) / 2;
           }
         }
-        const dLng = centerline[1][0] - centerline[0][0];
-        const dLat = centerline[1][1] - centerline[0][1];
-        const drawnHeading = ((Math.atan2(dLng, dLat) * 180) / Math.PI + 360) % 360;
+        // geographic bearing - naive atan2 on lng/lat deltas is off by several
+        // degrees at non-equatorial latitudes
+        const drawnHeading = computeBearing(
+          centerline[0][0], centerline[0][1], centerline[1][0], centerline[1][1],
+        );
 
-        const computedWidth = drawnWidth != null ? Math.round(drawnWidth * 100) / 100 : undefined;
+        // prefer user-entered form values over the derived ones
+        const formHeading = typeof data.heading === "number" ? data.heading : undefined;
+        const formLength = typeof data.length === "number" ? data.length : undefined;
+        const formWidth = typeof data.width === "number" ? data.width : undefined;
+
+        const roundedDrawnWidth = drawnWidth != null ? Math.round(drawnWidth * 100) / 100 : undefined;
+        const roundedDrawnLength = drawnLength != null ? Math.round(drawnLength * 100) / 100 : undefined;
+        const roundedDrawnHeading = Math.round(drawnHeading * 10) / 10;
+
         await createSurface(id, {
           identifier: String(data.name ?? ""),
           surface_type: entityType === "runway" ? "RUNWAY" : "TAXIWAY",
           geometry: { type: "LineString", coordinates: geomCoords },
           boundary: { type: "Polygon", coordinates: boundaryCoords },
-          heading: drawnHeading != null ? Math.round(drawnHeading * 10) / 10 : undefined,
-          length: drawnLength != null ? Math.round(drawnLength * 100) / 100 : undefined,
-          width: entityType === "runway" ? computedWidth : undefined,
+          heading: formHeading ?? roundedDrawnHeading,
+          length: formLength ?? roundedDrawnLength,
+          width: entityType === "runway" ? (formWidth ?? roundedDrawnWidth) : undefined,
         });
       } else if (entityType.startsWith("safety_zone_")) {
         if (!pendingGeometry) throw new Error("missing geometry");
@@ -675,8 +684,10 @@ export default function AirportEditPage() {
       try {
         await deleteAGL(id, surface.id, aglId);
         await fetchAirport();
-      } catch {
+      } catch (e) {
         setDeleteError(true);
+        // re-throw so the calling dialog can surface the error inline
+        throw e;
       }
     },
     [id, airport, fetchAirport],

--- a/frontend/src/pages/coordinator-center/AirportEditPage.tsx
+++ b/frontend/src/pages/coordinator-center/AirportEditPage.tsx
@@ -1159,6 +1159,7 @@ export default function AirportEditPage() {
                 feature={selectedFeature}
                 onUpdate={handleFeatureUpdate}
                 onClose={() => setSelectedFeature(null)}
+                airportId={id}
                 surfaces={surfaces}
                 onDelete={handleFeatureDelete}
                 deleteWarnings={

--- a/frontend/src/types/airport.ts
+++ b/frontend/src/types/airport.ts
@@ -147,7 +147,8 @@ export interface SurfaceCreate {
 export interface SurfaceUpdate {
   identifier?: string;
   geometry?: LineStringZ;
-  boundary?: PolygonZ;
+  // null clears the polygon boundary on the backend; undefined leaves it untouched
+  boundary?: PolygonZ | null;
   buffer_distance?: number;
   heading?: number | null;
   length?: number | null;

--- a/frontend/src/types/airport.ts
+++ b/frontend/src/types/airport.ts
@@ -170,6 +170,7 @@ export interface ObstacleUpdate {
   boundary?: PolygonZ;
   buffer_distance?: number;
   type?: ObstacleType;
+  preserve_altitude?: boolean;
 }
 
 export interface SafetyZoneCreate {
@@ -208,6 +209,7 @@ export interface AGLUpdate {
   glide_slope_angle?: number | null;
   distance_from_threshold?: number | null;
   offset_from_centerline?: number | null;
+  preserve_altitude?: boolean;
 }
 
 export interface LHACreate {
@@ -224,4 +226,28 @@ export interface LHAUpdate {
   transition_sector_width?: number | null;
   lamp_type?: LampType;
   position?: PointZ;
+  preserve_altitude?: boolean;
+}
+
+export interface SurfaceDimensions {
+  length: number | null;
+  width: number | null;
+  heading: number | null;
+}
+
+export interface SurfaceRecalculateResponse {
+  current: SurfaceDimensions;
+  recalculated: SurfaceDimensions;
+}
+
+export interface ObstacleDimensions {
+  length: number | null;
+  width: number | null;
+  heading: number | null;
+  radius: number | null;
+}
+
+export interface ObstacleRecalculateResponse {
+  current: ObstacleDimensions;
+  recalculated: ObstacleDimensions;
 }

--- a/frontend/src/utils/agl.test.ts
+++ b/frontend/src/utils/agl.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { formatAglDisplayName } from "./agl";
+import type { SurfaceType } from "@/types/enums";
+
+describe("formatAglDisplayName", () => {
+  it("formats PAPI on a runway as 'PAPI RWY {designator}'", () => {
+    const agl = { agl_type: "PAPI", name: "PAPI 1" };
+    const surface = { surface_type: "RUNWAY" as SurfaceType, identifier: "12/30" };
+    expect(formatAglDisplayName(agl, surface)).toBe("PAPI RWY 12/30");
+  });
+
+  it("falls back to agl.name when surface is missing", () => {
+    const agl = { agl_type: "PAPI", name: "PAPI 1" };
+    expect(formatAglDisplayName(agl, undefined)).toBe("PAPI 1");
+  });
+
+  it("falls back to agl.name when surface is not a runway", () => {
+    const agl = { agl_type: "PAPI", name: "PAPI 1" };
+    const surface = { surface_type: "TAXIWAY" as SurfaceType, identifier: "A1" };
+    expect(formatAglDisplayName(agl, surface)).toBe("PAPI 1");
+  });
+
+  it("falls back to agl.name when agl is not a PAPI", () => {
+    const agl = { agl_type: "REIL", name: "REIL 1" };
+    const surface = { surface_type: "RUNWAY" as SurfaceType, identifier: "06L/24R" };
+    expect(formatAglDisplayName(agl, surface)).toBe("REIL 1");
+  });
+});

--- a/frontend/src/utils/agl.ts
+++ b/frontend/src/utils/agl.ts
@@ -1,0 +1,17 @@
+import type { AGLResponse, SurfaceResponse } from "@/types/airport";
+
+/** format an AGL display name as "PAPI RWY {designator}" when applicable. */
+export function formatAglDisplayName(
+  agl: Pick<AGLResponse, "agl_type" | "name">,
+  surface?: Pick<SurfaceResponse, "surface_type" | "identifier"> | null,
+): string {
+  if (
+    agl.agl_type === "PAPI" &&
+    surface &&
+    surface.surface_type === "RUNWAY" &&
+    surface.identifier
+  ) {
+    return `PAPI RWY ${surface.identifier}`;
+  }
+  return agl.name;
+}


### PR DESCRIPTION
Closes #97

## Summary

Bundles five coordinator-center improvements that share the same code paths in `PoiInfoPanel`, `EditableFeatureInfo`, `LayerPanel`, and `airport_service`.

- **Task 1 — Recalculate dimensions** — `POST .../surfaces/{id}/recalculate` and `.../obstacles/{id}/recalculate` recompute length, width, and heading from stored geometry without persisting. Frontend renders a side-by-side current vs recalculated preview with Apply/Cancel.
- **Task 2 — T&L layer visibility default** — `addAllLayers` now syncs visibility from `layerConfigRef` immediately after creating layers, plus a mount-time poll-and-sync guard, so the LayerPanel toggle state matches actual MapLibre visibility.
- **Task 3 — PAPI naming convention** — new `formatAglDisplayName()` helper renders PAPI AGLs as `PAPI RWY {designator}` when the parent is a runway. Wired into `PoiInfoPanel` and `CoordinatorAGLPanel`. Display-only — no schema or data migration.
- **Task 4 — Transit waypoint rendering lag** — `addWaypointLayers` now updates `waypointsRef` from the override and calls `map.triggerRepaint()` after `setData`, so newly-inserted transit waypoints paint immediately instead of waiting for the next mouse interaction.
- **Task 5 — Full coordinates + manual editing** — `CoordRows` always shows altitude, polygon `PolygonCoordRows` includes vertex altitude, and `EditableFeatureInfo` now offers inline lat/lon/alt editing for AGL and LHA point geometry. New `preserve_altitude: bool` flag on `ObstacleUpdate`/`AGLUpdate`/`LHAUpdate` skips ground-altitude renormalization on coordinator-explicit edits.

## DDD-lite

`AirfieldSurface.recalculate_dimensions()` and `Obstacle.recalculate_dimensions()` are pure geometry methods on the model. Service functions are thin wrappers that fetch the entity and build the response DTO. Geometry helpers (`linestring_length`, `polygon_oriented_dimensions`) live in `app/utils/geo.py` — no Shapely dependency added.

## Risk tier

T2 — `airport_service.py` and `models/airport.py` are T2; `trajectory_computation.py` (T3) is **not** modified. The recalculated heading propagates via the existing `surface.heading` column read by `get_runway_heading()`.

## Test plan

- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && ruff format --check .` — clean
- [x] `cd backend && pytest` — 490 passed, 1 skipped (5 new tests for recalculate endpoints + preserve_altitude)
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run build` — clean (tsc -b + vite build)
- [x] `cd frontend && npx vitest run` — 320 passed (4 new tests for `formatAglDisplayName`)
- [x] `bash scripts/structural-tests.sh` — all architectural boundaries respected