### PR TITLE
fix: merge alembic heads for perpendicular crossing and speed override

### DIFF
--- a/backend/migrations/versions/b435c08f47f1_merge_perpendicular_crossing_and_speed_.py
+++ b/backend/migrations/versions/b435c08f47f1_merge_perpendicular_crossing_and_speed_.py
@@ -1,0 +1,26 @@
+"""merge perpendicular crossing and speed override branches
+
+Revision ID: b435c08f47f1
+Revises: 538f931cfdcc, f1a2b3c4d5e6
+Create Date: 2026-04-17 14:00:13.470012
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+
+
+revision: str = 'b435c08f47f1'
+down_revision: Union[str, None] = ('538f931cfdcc', 'f1a2b3c4d5e6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Merge migration resolving two alembic heads (`538f931cfdcc` speed override + `f1a2b3c4d5e6` perpendicular crossing) that both branched from `e9f0a1b2c3d4`
- Fixes 500 error on `/api/v1/missions` due to missing `require_perpendicular_runway_crossing` column

## Risk Tier
- [x] T1

## Test plan
- [ ] `alembic upgrade head` runs without errors
- [ ] `/api/v1/missions` endpoint returns 200