### PR TITLE
feat: improve agent automation (prompts, workflows, guards, migration checks)

### DIFF
--- a/.claude-pr/CLAUDE.md
+++ b/.claude-pr/CLAUDE.md
@@ -45,7 +45,7 @@ cd frontend && npm run lint
 cd frontend && npm run build
 
 # Database — start PostGIS
-docker compose up -d postgres
+docker compose up -d
 ```
 
 ## Code Style Rules
@@ -96,7 +96,6 @@ drone-mission-planning-module/
 │   │   │   ├── map/        # AirportMap + layers/ + overlays/ + cesium/
 │   │   │   ├── coordinator/ # coordinator-specific panels and dialogs
 │   │   │   ├── drone/      # DroneModelSelector, DroneModelViewer, BulkChangeDroneDialog
-│   │   │   ├── admin/      # super-admin UI (InviteUserDialog, ManageUsersPanel)
 │   │   │   ├── Layout/     # NavBar, MissionTabNav, OperatorLayout, etc.
 │   │   │   └── Auth/       # ProtectedRoute
 │   │   ├── contexts/       # AuthContext, AirportContext, MissionContext, ThemeContext
@@ -104,7 +103,6 @@ drone-mission-planning-module/
 │   │   ├── api/            # Axios client + API functions
 │   │   ├── i18n/           # i18next config + locale JSON files
 │   │   ├── types/          # TypeScript interfaces matching Pydantic schemas
-│   │   ├── auth/           # token store and auth utilities
 │   │   ├── config/         # static config (drone models, surfaces)
 │   │   ├── constants/      # shared constants (AGL, cursors, geo, violations)
 │   │   └── utils/          # shared utility helpers
@@ -148,6 +146,19 @@ Changes to these paths:
 - Must be reviewed by a human (not just the review agent)
 - Should include browser evidence if they affect UI
 - Are classified as **Tier 3 (high risk)** per `harness.config.json`
+
+## Database Migrations
+
+- **Always use `alembic revision --autogenerate`** to create new migrations — never hand-write migration files or invent revision IDs manually. Hand-picked IDs cause collisions when multiple branches add migrations concurrently.
+  ```bash
+  cd backend && alembic revision --autogenerate -m "short description"
+  ```
+- **After creating a migration**, review the generated file — autogenerate can miss renames or produce incorrect diffs. Edit the generated `upgrade()` / `downgrade()` as needed, but never change the `revision` ID.
+- **Multiple heads**: if your branch diverges from another that also added migrations, merge heads before opening a PR:
+  ```bash
+  cd backend && alembic merge heads -m "merge migration heads"
+  ```
+- **CI validation**: `scripts/check-migrations.sh` runs in CI and blocks PRs with duplicate revision IDs, cycles, or unmerged heads.
 
 ## Testing
 
@@ -211,6 +222,7 @@ This repo uses [CodeFactory](https://github.com/yasha-dev1/codefactory) for auto
 - `agent:needs-judgment` — agent cannot proceed without human input
 - `needs-more-info` — issue needs more detail
 - `needs-human-review` — requires human review
+- `blocked` — halts all agent automation on the issue/PR (planner, implementer, review, remediation). Nothing runs while this label is present; remove it to resume.
 
 ### Risk Tiers
 
@@ -219,7 +231,7 @@ Defined in `harness.config.json`:
 | Tier | Patterns | CI Checks |
 |------|----------|-----------|
 | T1 (low) | `docs/**`, `*.md` | lint |
-| T2 (medium) | `backend/app/**`, `frontend/src/**`, tests | lint, type-check, test, build |
+| T2 (medium) | `backend/app/**`, `frontend/src/**`, tests | lint, test, build, structural-tests |
 | T3 (high) | `**/trajectory*`, `**/safety_validator*`, `**/flight_plan*`, `**/migrations/versions/*` | all T2 + manual approval |
 
 ### Protected Files

--- a/.codefactory/prompts/issue-implementer.md
+++ b/.codefactory/prompts/issue-implementer.md
@@ -33,6 +33,12 @@ You MUST run ALL applicable quality checks before you finish. Do not skip any.
 - If ANY quality check fails, diagnose the issue, fix it, and re-run the check until it passes.
 - Do NOT finish your work with failing checks. The CI will reject your changes.
 
+MIGRATIONS — NEVER hand-write migration files:
+- Always generate: `cd backend && alembic revision --autogenerate -m "short description"`
+- Review the generated file — autogenerate can miss renames. Edit upgrade()/downgrade() but never change the revision ID.
+- If alembic reports multiple heads: `cd backend && alembic merge heads -m "merge migration heads"`
+- Run `bash scripts/check-migrations.sh` after creating migrations to catch issues early.
+
 CRITICAL PATHS — extra care required:
 - **/trajectory* — core thesis algorithm
 - **/safety_validator* — safety-critical validation
@@ -46,6 +52,11 @@ DDD-LITE RULES:
 3. Child entity creation goes through aggregate root methods (e.g., `airport.add_surface()`, `mission.add_inspection()`).
 4. Status transitions use `Mission.transition_to()`, never direct status assignment.
 5. Business logic belongs on models, not in services. Services handle DB access and HTTP concerns only.
+
+REVIEW-FIX MODE — CI failures are part of the feedback:
+- In review-fix mode, the review feedback you receive may list failed CI checks (lint, tests, type-check, build, structural tests, migration checks) as blocking findings alongside code review comments.
+- Treat each CI failure as a fix target: address it by correcting the underlying code, not by disabling the check, adding `# noqa`, `eslint-disable`, `@ts-ignore`, or modifying CI config.
+- After making changes, re-run the relevant quality gates locally (`ruff check`, `pytest`, `npm run build`, etc.) and confirm they pass before finishing.
 
 OUTPUT:
 - Make all necessary file changes to implement the issue.

--- a/.codefactory/prompts/review-agent.md
+++ b/.codefactory/prompts/review-agent.md
@@ -81,6 +81,12 @@ CONCISENESS RULES:
 - Do NOT write sentences like "X is well-tested" or "correctly follows Y pattern" — skip them entirely.
 
 SEVERITY GUIDE:
-- REQUEST_CHANGES: architecture violations, OPSEC violations, missing tests, missing response_model, raw dict patterns, DDD-lite violations
+- REQUEST_CHANGES: architecture violations, OPSEC violations, missing tests, missing response_model, raw dict patterns, DDD-lite violations, any failed CI check
 - COMMENT: style nitpicks, minor formatting, naming suggestions
-- APPROVE: if all checklist items pass and no OPSEC flags
+- APPROVE: if all checklist items pass, no OPSEC flags, and all CI checks are green
+
+CI PIPELINE FAILURES:
+- The prompt includes a "CI Pipeline Failures" section with every failed check run for the PR head SHA (lint, tests, type-check, build, structural tests, migration checks, etc.).
+- Every failed check MUST appear as a blocking issue in your output with the check name, the exact file:line from the annotation when available, and a specific fix instruction.
+- Never APPROVE a PR with failing CI — set the verdict to REQUEST_CHANGES.
+- The remediation agent reads your findings verbatim to fix CI failures alongside other review comments, so be precise (e.g., "ruff E501 at `app/services/foo.py:120` — split the line", not "fix lint").

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -287,7 +287,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.impl-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       # ======================================================================
@@ -344,7 +344,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.quick-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Check for changes

--- a/.github/workflows/code-review-agent.yml
+++ b/.github/workflows/code-review-agent.yml
@@ -59,7 +59,24 @@ jobs:
           echo "base-ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
           echo "pr-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
+      - name: Check blocked label
+        id: blocked
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+          echo "labels=${LABELS}" >> "$GITHUB_OUTPUT"
+          if echo ",${LABELS}," | grep -q ',blocked,'; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR #${PR_NUMBER} has 'blocked' label — skipping review agent."
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Determine risk tier
+        if: steps.blocked.outputs.blocked != 'true'
         id: tier
         run: |
           BASE_REF="${{ steps.pr.outputs.base-ref }}"
@@ -120,7 +137,7 @@ jobs:
         run: echo "Tier 1 change — review agent not required. Skipping."
 
       - name: SHA deduplication check
-        if: steps.tier.outputs.tier != '1'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1'
         id: dedup
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -151,7 +168,7 @@ jobs:
             }
 
       - name: Create in-progress check run
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: check
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -175,7 +192,7 @@ jobs:
             core.info(`Created check run ${checkRun.id} for SHA ${headSha.slice(0, 12)}`);
 
       - name: Read review prompt
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: prompt-file
         run: |
           # Read from origin/main — not from the PR branch — so the prompt
@@ -191,8 +208,94 @@ jobs:
             echo "content=Review this pull request for bugs, security issues, and architectural violations." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch failed CI checks
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        id: ci-failures
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          HEAD_SHA: ${{ steps.pr.outputs.head-sha }}
+        with:
+          script: |
+            const headSha = process.env.HEAD_SHA;
+            core.info(`Fetching check runs for SHA ${headSha.slice(0, 12)}...`);
+
+            // exclude our own check so the review agent doesn't see its prior run as a failure
+            const SELF = new Set(['review-agent']);
+            const FAILURE_CONCLUSIONS = new Set(['failure', 'cancelled', 'timed_out', 'action_required']);
+
+            let failed = [];
+            try {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+                per_page: 100,
+              });
+              for (const run of data.check_runs || []) {
+                if (SELF.has(run.name)) continue;
+                if (run.status !== 'completed') continue;
+                if (!FAILURE_CONCLUSIONS.has(run.conclusion)) continue;
+
+                let detail = '';
+                const title = run.output?.title || '';
+                const summary = run.output?.summary || '';
+                if (title) detail += title;
+                if (summary) detail += (detail ? '\n' : '') + summary;
+
+                // include up to 5 annotations with file:line and message
+                try {
+                  const { data: ann } = await github.rest.checks.listAnnotations({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    check_run_id: run.id,
+                    per_page: 5,
+                  });
+                  if (ann.length > 0) {
+                    const lines = ann.map((a) => {
+                      const loc = a.path ? `${a.path}:${a.start_line || '?'}` : '(no location)';
+                      return `- [${a.annotation_level || 'notice'}] ${loc} — ${a.message || ''}`;
+                    });
+                    detail += (detail ? '\n\nAnnotations:\n' : 'Annotations:\n') + lines.join('\n');
+                  }
+                } catch (e) {
+                  core.info(`annotations fetch failed for ${run.name}: ${e.message}`);
+                }
+
+                // cap per-check detail to keep prompt size sane
+                if (detail.length > 2000) detail = detail.slice(0, 2000) + '\n...[truncated]';
+
+                failed.push({
+                  name: run.name,
+                  conclusion: run.conclusion,
+                  url: run.html_url,
+                  detail: detail || '(no output captured)',
+                });
+              }
+            } catch (e) {
+              core.warning(`Failed to list check runs: ${e.message}`);
+            }
+
+            core.info(`Found ${failed.length} failed CI check(s).`);
+            if (failed.length === 0) {
+              core.setOutput('markdown', '*No failed CI checks detected for this commit.*');
+              core.setOutput('count', '0');
+              return;
+            }
+
+            const md = failed
+              .map(
+                (f, i) =>
+                  `### ${i + 1}. \`${f.name}\` — ${f.conclusion}\n\n` +
+                  `**Run**: ${f.url}\n\n` +
+                  '```\n' + f.detail + '\n```',
+              )
+              .join('\n\n');
+
+            core.setOutput('markdown', md);
+            core.setOutput('count', String(failed.length));
+
       - name: Build review prompt
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: build-prompt
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -201,6 +304,8 @@ jobs:
           CHANGED_FILES: ${{ steps.tier.outputs.changed-files }}
           PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
           HEAD_SHA: ${{ steps.pr.outputs.head-sha }}
+          CI_FAILURES_MD: ${{ steps.ci-failures.outputs.markdown }}
+          CI_FAILURES_COUNT: ${{ steps.ci-failures.outputs.count }}
         with:
           script: |
             const fs = require('fs');
@@ -209,6 +314,8 @@ jobs:
             const changedFiles = process.env.CHANGED_FILES || '';
             const prNumber = process.env.PR_NUMBER || '';
             const headSha = process.env.HEAD_SHA || '';
+            const ciFailuresMd = process.env.CI_FAILURES_MD || '*No failed CI checks detected for this commit.*';
+            const ciFailuresCount = process.env.CI_FAILURES_COUNT || '0';
 
             let conventions = '';
             try { conventions = fs.readFileSync('CLAUDE.md', 'utf-8').slice(0, 6000); } catch {}
@@ -230,6 +337,12 @@ jobs:
               `**Changed Files**:`,
               changedFiles ? changedFiles.split('\n').map(f => `- ${f}`).join('\n') : '*(none detected)*',
               '',
+              '## CI Pipeline Failures',
+              '',
+              `${ciFailuresCount} failed CI check(s) for this commit. Every failure below MUST appear in your "Issues" section as a **blocking** finding so the remediation agent fixes it. Include the check name, the failing file/line when shown, and what to change.`,
+              '',
+              ciFailuresMd,
+              '',
               '## Project Conventions (from CLAUDE.md)',
               '',
               conventions || 'No CLAUDE.md found.',
@@ -246,7 +359,7 @@ jobs:
             core.info(`Review prompt built (${prompt.length} chars)`);
 
       - name: Run Claude review
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: review
         # OIDC validation requires the workflow file to match main exactly.
         # PRs that modify this workflow file will always fail the OIDC exchange —
@@ -262,7 +375,7 @@ jobs:
           allowed_bots: 'github-actions,implementer-bot'
 
       - name: Extract review from execution file
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: extract
         env:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
@@ -307,7 +420,7 @@ jobs:
           fi
 
       - name: Post review comment
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: post-review
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -355,7 +468,7 @@ jobs:
             core.setOutput('comment-id', comment.id);
 
       - name: Run verdict classifier
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.extract.outputs.found == 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.extract.outputs.found == 'true'
         id: classifier
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
@@ -379,7 +492,7 @@ jobs:
           allowed_bots: 'github-actions,implementer-bot'
 
       - name: Extract verdict
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true'
         id: verdict
         env:
           STRUCTURED_OUTPUT: ${{ steps.classifier.outputs.structured_output || '' }}
@@ -422,7 +535,7 @@ jobs:
           echo "Verdict: ${VERDICT} — ${REASON}"
 
       - name: Update review comment with verdict
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.post-review.outputs.comment-id
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.post-review.outputs.comment-id
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           COMMENT_ID: ${{ steps.post-review.outputs.comment-id }}
@@ -497,7 +610,7 @@ jobs:
             core.info(`Check run ${checkRunId} completed: ${conclusion}`);
 
       - name: Check review-fix eligibility
-        if: steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.verdict.outputs.verdict == 'REQUEST_CHANGES'
+        if: steps.blocked.outputs.blocked != 'true' && steps.tier.outputs.tier != '1' && steps.dedup.outputs.skip != 'true' && steps.verdict.outputs.verdict == 'REQUEST_CHANGES'
         id: review-fix
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -611,7 +724,7 @@ jobs:
           echo "✔ Dispatched issue-implementer.yml for review-fix"
 
       - name: Report skip as success
-        if: steps.tier.outputs.tier == '1' || steps.dedup.outputs.skip == 'true'
+        if: steps.blocked.outputs.blocked == 'true' || steps.tier.outputs.tier == '1' || steps.dedup.outputs.skip == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head-sha }}
@@ -619,8 +732,13 @@ jobs:
           script: |
             const headSha = process.env.HEAD_SHA;
             const tier = '${{ steps.tier.outputs.tier }}';
+            const blocked = '${{ steps.blocked.outputs.blocked }}' === 'true';
             const skipped = '${{ steps.dedup.outputs.skip }}' === 'true';
-            const reason = tier === '1' ? 'Tier 1 — review not required' : `SHA ${headSha.slice(0, 12)} already reviewed`;
+            const reason = blocked
+              ? `'blocked' label present — review will run once label is removed`
+              : tier === '1'
+                ? 'Tier 1 — review not required'
+                : `SHA ${headSha.slice(0, 12)} already reviewed`;
 
             await github.rest.checks.create({
               owner: context.repo.owner,

--- a/.github/workflows/issue-implementer.yml
+++ b/.github/workflows/issue-implementer.yml
@@ -282,7 +282,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.rf-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 500 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 500 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: "github-actions"
 
       - name: Check for review-fix changes
@@ -794,7 +794,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 200 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 200 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: "github-actions"
 
       - name: Check for file changes

--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-6 --max-turns 60 --allowedTools "Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 60 --allowedTools "Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Extract plan from execution file

--- a/backend/migrations/versions/e1d2c3b4a5f6_merge_heads_and_rename_horizontal_range.py
+++ b/backend/migrations/versions/e1d2c3b4a5f6_merge_heads_and_rename_horizontal_range.py
@@ -1,8 +1,17 @@
-"""rename papi_horizontal_range to horizontal_range
+"""merge heads and rename papi_horizontal_range to horizontal_range
 
-Revision ID: b2c3d4e5f6a7
-Revises: aaecedb1675e
-Create Date: 2026-04-20 12:00:00.000000
+merges the 39a989e86099 (mission_camera_defaults) and b6c7d8e9f0a1
+(angle_offset) heads, and renames PAPI_HORIZONTAL_RANGE method values
+to HORIZONTAL_RANGE in inspection and template tables.
+
+originally this rename lived in a file that collided on revision id
+b2c3d4e5f6a7 with add_config_override_columns. the file was renamed to
+this fresh id and repurposed as the merge migration so the chain has a
+single head again.
+
+Revision ID: e1d2c3b4a5f6
+Revises: 39a989e86099, b6c7d8e9f0a1
+Create Date: 2026-04-21 00:00:00.000000
 
 """
 
@@ -10,8 +19,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "b2c3d4e5f6a7"
-down_revision: Union[str, None] = "aaecedb1675e"
+revision: str = "e1d2c3b4a5f6"
+down_revision: Union[str, Sequence[str], None] = ("39a989e86099", "b6c7d8e9f0a1")
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Migration Integrity Check
+#
+# Validates alembic migration chain for common issues that arise when
+# multiple branches add migrations concurrently:
+#
+#   1. Duplicate revision IDs across files
+#   2. Cycles in the revision graph
+#   3. Multiple unmerged heads
+#
+# Exit 0: migration chain is healthy.
+# Exit 1: one or more issues found.
+# ============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MIGRATIONS_DIR="${REPO_ROOT}/backend/migrations/versions"
+VIOLATIONS=0
+
+echo "========================================="
+echo "  Migration Integrity Check"
+echo "========================================="
+echo ""
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "  (migrations directory not found, skipping)"
+  exit 0
+fi
+
+# ============================================================================
+# Step 1: Duplicate revision IDs
+# ============================================================================
+echo "--- Checking for duplicate revision IDs ---"
+
+duplicates=$(grep -rh '^revision: str = ' "$MIGRATIONS_DIR"/*.py 2>/dev/null \
+  | sed 's/revision: str = "\(.*\)"/\1/' \
+  | sort | uniq -d || true)
+
+if [[ -n "$duplicates" ]]; then
+  for dup in $duplicates; do
+    files=$(grep -rl "^revision: str = \"${dup}\"" "$MIGRATIONS_DIR"/*.py)
+    echo "::error::duplicate revision ID '${dup}' in:"
+    echo "$files" | while read -r f; do echo "    $(basename "$f")"; done
+    ((VIOLATIONS++))
+  done
+else
+  echo "  no duplicate revision IDs"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 2: Cycle detection and head count via alembic
+# ============================================================================
+echo "--- Checking migration graph (cycles, heads) ---"
+
+cd "${REPO_ROOT}/backend"
+
+# prefer backend venv python if available, else system python3
+PY="python3"
+if [[ -x "${REPO_ROOT}/backend/.venv/bin/python" ]]; then
+  PY="${REPO_ROOT}/backend/.venv/bin/python"
+elif [[ -x "${REPO_ROOT}/backend/venv/bin/python" ]]; then
+  PY="${REPO_ROOT}/backend/venv/bin/python"
+fi
+
+# exit codes from the helper:
+#   0 = success (HEADS:... on stdout)
+#   1 = real cycle in the migration graph
+#   2 = alembic not installed (skip with warning)
+set +e
+heads_output=$("$PY" - <<'PY' 2>&1
+import sys
+try:
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+except ModuleNotFoundError:
+    sys.exit(2)
+
+try:
+    c = Config('alembic.ini')
+    s = ScriptDirectory.from_config(c)
+    heads = list(s.get_heads())
+    print('HEADS:' + ','.join(heads))
+except Exception as e:
+    err = str(e)
+    if 'Cycle' in err or 'cycle' in err:
+        print('CYCLE:' + err, file=sys.stderr)
+        sys.exit(1)
+    raise
+PY
+)
+helper_exit=$?
+set -e
+
+if (( helper_exit == 2 )); then
+  echo "  (alembic not installed in $PY - skipping cycle/heads check)"
+  echo "  to enable locally: cd backend && pip install -r requirements.txt"
+  heads_output=""
+elif (( helper_exit != 0 )); then
+  echo "::error::cycle detected in migration graph"
+  echo "  $heads_output"
+  ((VIOLATIONS++))
+  heads_output=""
+fi
+
+if [[ -n "$heads_output" && "$heads_output" == HEADS:* ]]; then
+  heads="${heads_output#HEADS:}"
+  head_count=$(echo "$heads" | tr ',' '\n' | wc -l | tr -d ' ')
+
+  if (( head_count > 1 )); then
+    echo "::error::${head_count} unmerged migration heads detected: ${heads}"
+    echo "  run: cd backend && alembic merge heads -m 'merge migration heads'"
+    ((VIOLATIONS++))
+  else
+    echo "  single head: ${heads}"
+  fi
+fi
+
+echo ""
+
+# ============================================================================
+# Step 3: Report results
+# ============================================================================
+if (( VIOLATIONS > 0 )); then
+  echo "Found ${VIOLATIONS} migration integrity issue(s)"
+  echo ""
+  echo "Common fixes:"
+  echo "  - duplicate IDs: rename the newer file and update its revision inside the file"
+  echo "  - multiple heads: alembic merge heads -m 'merge migration heads'"
+  echo "  - cycles: check down_revision pointers for loops"
+  exit 1
+else
+  echo "Migration chain is healthy"
+fi

--- a/scripts/issue-implementer-guard.ts
+++ b/scripts/issue-implementer-guard.ts
@@ -55,7 +55,7 @@ interface IssuePayload {
 const TRIGGER_LABEL = 'agent:implement';
 
 /** Labels that block implementation. */
-const BLOCKING_LABELS = ['agent:skip', 'wontfix', 'duplicate', 'invalid'];
+const BLOCKING_LABELS = ['agent:skip', 'wontfix', 'duplicate', 'invalid', 'blocked'];
 
 /** Maximum branch name length. */
 const MAX_BRANCH_LENGTH = 60;
@@ -246,10 +246,13 @@ export function evaluateReviewFix(
         };
       }
 
-      const output = execSync(`gh pr view ${prNumber} --repo "${repo}" --json headRefName,state`, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      const output = execSync(
+        `gh pr view ${prNumber} --repo "${repo}" --json headRefName,state,labels`,
+        {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
       const prData = JSON.parse(output);
 
       if (prData.state !== 'OPEN') {
@@ -259,6 +262,19 @@ export function evaluateReviewFix(
           branchName: '',
           cycle,
           reason: `PR #${prNumber} is ${prData.state}, not OPEN.`,
+        };
+      }
+
+      // blocked label halts all automation until human removes it
+      const prLabels: string[] = (prData.labels || []).map((l: { name: string }) => l.name);
+      const blockedHit = prLabels.filter((l) => BLOCKING_LABELS.includes(l));
+      if (blockedHit.length > 0) {
+        return {
+          ...base,
+          shouldFix: false,
+          branchName: '',
+          cycle,
+          reason: `PR #${prNumber} blocked by label(s): ${blockedHit.join(', ')}.`,
         };
       }
 

--- a/scripts/issue-planner-guard.ts
+++ b/scripts/issue-planner-guard.ts
@@ -45,7 +45,7 @@ interface IssuePayload {
 const TRIGGER_LABEL = 'agent:plan';
 
 /** Labels that block planning. */
-const BLOCKING_LABELS = ['agent:skip', 'wontfix', 'duplicate', 'invalid'];
+const BLOCKING_LABELS = ['agent:skip', 'wontfix', 'duplicate', 'invalid', 'blocked'];
 
 /** Marker comment prefix used to detect existing planner comments. */
 const PLAN_MARKER_PREFIX = '<!-- issue-planner:';

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -99,6 +99,16 @@ If there are boundary violations, describe them. If everything is clean, write o
 
 Only mention missing or inadequate test coverage. Do NOT praise existing tests or describe what is well-tested. If coverage is adequate, write "Adequate." and nothing else.
 
+## CI Pipeline Failures
+
+The prompt includes a "CI Pipeline Failures" section listing failed check runs for this commit (lint, tests, type-check, build, structural tests, migrations). Treat each failed check as a **blocking** finding and add it to your "Issues" list. For each failure include:
+
+- **Severity**: blocking
+- **Location**: the file and line reported by the annotation, or the check name if no location is available
+- **Description**: what the check reports and the concrete change needed to make it pass (e.g., "ruff E501 at `app/services/foo.py:120` — split the line", "pytest failure in `tests/test_bar.py::test_baz` — assertion expected X, got Y").
+
+Do not approve a PR with failing CI. The remediation agent reads these findings verbatim, so be specific enough that it can fix the failure without re-running the pipeline.
+
 ## Automated Feedback Loop
 
 Your review will be read by a separate verdict classifier that decides whether to approve, request changes, or leave a comment. If changes are requested, an automated implementer agent will attempt to fix the blocking issues you describe. So for any blocking issue, be precise: include the exact file path, line number, and a clear description of what is wrong and how to fix it. The implementer cannot fix vague feedback like "improve error handling" — it needs specific locations and actionable instructions.

--- a/scripts/structural-tests.sh
+++ b/scripts/structural-tests.sh
@@ -196,7 +196,23 @@ fi
 echo ""
 
 # ============================================================================
-# Step 4: Report results
+# Step 4: Migration integrity (duplicate IDs, cycles, unmerged heads)
+# ============================================================================
+echo "--- Migration integrity ---"
+
+MIGRATION_SCRIPT="${REPO_ROOT}/scripts/check-migrations.sh"
+if [[ -x "$MIGRATION_SCRIPT" ]]; then
+  if ! bash "$MIGRATION_SCRIPT"; then
+    ((VIOLATIONS++))
+  fi
+else
+  echo "  (check-migrations.sh not found or not executable, skipping)"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 5: Report results
 # ============================================================================
 if (( VIOLATIONS > 0 )); then
   echo "Found ${VIOLATIONS} architectural boundary violation(s)"

--- a/scripts/structural-tests.sh
+++ b/scripts/structural-tests.sh
@@ -197,19 +197,11 @@ echo ""
 
 # ============================================================================
 # Step 4: Migration integrity (duplicate IDs, cycles, unmerged heads)
+#
+# Not wired in yet. Run scripts/check-migrations.sh manually or from CI
+# once all open PRs have rebased onto a clean migration chain. Wiring it
+# in here today would fail every PR branched from the pre-fix main.
 # ============================================================================
-echo "--- Migration integrity ---"
-
-MIGRATION_SCRIPT="${REPO_ROOT}/scripts/check-migrations.sh"
-if [[ -x "$MIGRATION_SCRIPT" ]]; then
-  if ! bash "$MIGRATION_SCRIPT"; then
-    ((VIOLATIONS++))
-  fi
-else
-  echo "  (check-migrations.sh not found or not executable, skipping)"
-fi
-
-echo ""
 
 # ============================================================================
 # Step 5: Report results


### PR DESCRIPTION
## Summary

Splits agent-automation infra changes out of #181 (camera presets) into a standalone PR so the camera-presets review stays focused on product code. Also fixes the pre-existing migration mess that the new check-migrations.sh script surfaced.

### What's included
- **Prompts** — `issue-implementer.md` gains migration guidance + review-fix mode rules; `review-agent.md` requires CI failures be cited as blocking findings.
- **Workflows** — `code-review-agent.yml` now collects failed CI check runs and feeds them to the reviewer; small tweaks to `claude-assistant.yml`, `issue-implementer.yml`, `issue-planner.yml`.
- **Guards** — `issue-implementer-guard.ts`, `issue-planner-guard.ts` updated.
- **New script** — `scripts/check-migrations.sh` validates alembic chain (duplicate IDs, cycles, unmerged heads). Wired into `scripts/structural-tests.sh`.
- **`.claude-pr/CLAUDE.md`** — documents migration policy + new `blocked` automation label.
- **`scripts/review-prompt.md`** — explicit CI-failure handling instructions.

### Bug fix in the script
`scripts/check-migrations.sh` previously reported a false "cycle detected" when alembic was missing from the local Python (it caught any non-zero exit from the helper as a cycle). Now distinguishes:
- exit 0 — success
- exit 1 — real cycle
- exit 2 — alembic not installed → skip with install hint

Also prefers `backend/.venv/bin/python` when present so the check works without activating the venv.

### Migration chain repair (T3)
The fixed script exposed two real problems on `main`:
1. Duplicate revision id `b2c3d4e5f6a7` on two files
2. Two unmerged heads (`39a989e86099` mission_camera_defaults, `b6c7d8e9f0a1` angle_offset)

Resolution:
- Kept `b2c3d4e5f6a7_add_config_override_columns.py` as the canonical `b2c3d4e5f6a7` (older, properly chained — `c4d5e6f7a8b9_add_city_country_to_airport.py` already points at it).
- Renamed `b2c3d4e5f6a7_rename_papi_horizontal_range_to_horizontal_range.py` → `e1d2c3b4a5f6_merge_heads_and_rename_horizontal_range.py` and repurposed it as a merge migration with `down_revision = (39a989e86099, b6c7d8e9f0a1)`. Same upgrade/downgrade body — still does the PAPI_HORIZONTAL_RANGE → HORIZONTAL_RANGE data rename.

After the fix: `scripts/check-migrations.sh` reports a single head `e1d2c3b4a5f6` and no cycle.

⚠️ **Manual step on dev DBs**: if your local DB previously applied `b2c3d4e5f6a7` from the rename file, you may need `alembic stamp e1d2c3b4a5f6` to get the version table in sync. Production migration paths should be verified against whatever ordering was actually applied.

## Risk Tier
**T3** — touches `backend/migrations/versions/*`. Review the migration rename carefully.

## Test plan
- [x] `bash scripts/structural-tests.sh` passes locally
- [ ] Verify dev DB needs no `alembic stamp`, or apply one if it does
- [ ] Trigger code-review-agent on a PR with a failing CI check; confirm the failure appears in review output