### PR TITLE
chore: bump codefactory agents to opus xhigh, sonnet high review

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.planner-prompt.outputs.prompt }}
-          claude_args: '--max-turns 30 --allowedTools "Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 30 --effort xhigh --allowedTools "Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Extract plan
@@ -287,7 +287,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.impl-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 100 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       # ======================================================================
@@ -344,7 +344,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.quick-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 100 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 100 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Check for changes

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -280,15 +280,20 @@ jobs:
             const prompt = sections.join('\n');
             core.setOutput('prompt', prompt);
 
-      - name: Run implementer (plan mode)
+      - name: Dispatch issue-implementer (plan mode)
         if: steps.instruction.outputs.mode == 'plan'
         id: implementer
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: ${{ steps.impl-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 100 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
-          allowed_bots: 'github-actions'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr-number }}
+          ASSISTANT_PROMPT: ${{ steps.impl-prompt.outputs.prompt }}
+        run: |
+          # hand the prompt to the full implementer agent - max-turns 500, separate job, full commit/push pipeline.
+          gh workflow run issue-implementer.yml \
+            --repo "${{ github.repository }}" \
+            -f pr_number="$PR_NUMBER" \
+            -f assistant_prompt="$ASSISTANT_PROMPT"
+          echo "dispatched issue-implementer for PR #${PR_NUMBER} (${#ASSISTANT_PROMPT} prompt chars)"
 
       # ======================================================================
       # QUICK MODE — skip planning, execute directly
@@ -344,10 +349,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.quick-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 100 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 200 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Check for changes
+        if: steps.instruction.outputs.mode == 'quick'
         id: changes
         run: |
           CHANGED=$(git diff --name-only 2>/dev/null || echo "")
@@ -362,7 +368,7 @@ jobs:
           fi
 
       - name: Commit and push
-        if: steps.changes.outputs.has-changes == 'true'
+        if: steps.instruction.outputs.mode == 'quick' && steps.changes.outputs.has-changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
@@ -397,13 +403,14 @@ jobs:
             const fileCount = process.env.FILE_COUNT;
             const mode = process.env.MODE;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const planDispatched = mode === 'plan';
 
-            // add reaction to original comment
+            // add reaction to original comment - plan mode hands off, so 'eyes' signals work in progress
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: parseInt(process.env.ORIGINAL_COMMENT_ID),
-              content: hasChanges ? 'rocket' : 'confused',
+              content: planDispatched ? 'eyes' : (hasChanges ? 'rocket' : 'confused'),
             });
 
             // update plan comment if it exists (plan mode)
@@ -417,9 +424,11 @@ jobs:
               let body = existing.body || '';
               body = body.replace(
                 'Implementing now...',
-                hasChanges
-                  ? `Done — pushed ${fileCount} file(s).`
-                  : 'No changes were needed.',
+                planDispatched
+                  ? 'Dispatched to issue-implementer — see the Actions tab for progress.'
+                  : (hasChanges
+                      ? `Done — pushed ${fileCount} file(s).`
+                      : 'No changes were needed.'),
               );
 
               await github.rest.issues.updateComment({

--- a/.github/workflows/code-review-agent.yml
+++ b/.github/workflows/code-review-agent.yml
@@ -371,7 +371,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--max-turns 100 --allowedTools "Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 100 --effort high --allowedTools "Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions,implementer-bot'
 
       - name: Extract review from execution file

--- a/.github/workflows/doc-gardening.yml
+++ b/.github/workflows/doc-gardening.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: 'Read and follow the instructions in scripts/doc-gardening-prompt.md to perform documentation gardening on this repository.'
-          claude_args: '--max-turns 20 --allowedTools "Read,Glob,Grep,Edit,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 20 --effort xhigh --allowedTools "Read,Glob,Grep,Edit,Bash"'
 
       - name: Revert non-documentation changes
         id: safety

--- a/.github/workflows/issue-implementer.yml
+++ b/.github/workflows/issue-implementer.yml
@@ -17,6 +17,10 @@ on:
         description: "Review-fix cycle number (1-3)"
         required: false
         type: string
+      assistant_prompt:
+        description: "Pre-built prompt from claude-assistant plan-mode handoff"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -55,13 +59,62 @@ jobs:
       - name: Determine mode
         id: mode
         run: |
-          if [[ -n "${{ inputs.pr_number }}" ]]; then
+          if [[ -n "${{ inputs.assistant_prompt }}" ]]; then
+            echo "mode=assistant-handoff" >> "$GITHUB_OUTPUT"
+            echo "Mode: assistant-handoff (PR #${{ inputs.pr_number }})"
+          elif [[ -n "${{ inputs.pr_number }}" ]]; then
             echo "mode=review-fix" >> "$GITHUB_OUTPUT"
             echo "Mode: review-fix (PR #${{ inputs.pr_number }}, cycle ${{ inputs.review_fix_cycle || '1' }})"
           else
             echo "mode=issue" >> "$GITHUB_OUTPUT"
             echo "Mode: issue implementation"
           fi
+
+      # ======================================================================
+      # ASSISTANT-HANDOFF MODE — execute plan from claude-assistant PR comment
+      # ======================================================================
+
+      - name: Checkout PR branch (assistant-handoff)
+        if: steps.mode.outputs.mode == 'assistant-handoff'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          BRANCH=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+          git config user.name "implementer-bot[bot]"
+          git config user.email "implementer-bot[bot]@users.noreply.github.com"
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          echo "✔ Checked out branch ${BRANCH} at SHA ${ACTUAL_SHA:0:12}"
+
+      - name: Run Claude (assistant-handoff)
+        if: steps.mode.outputs.mode == 'assistant-handoff'
+        id: ah-claude
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ inputs.assistant_prompt }}
+          claude_args: '--model claude-opus-4-7 --max-turns 500 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          allowed_bots: "github-actions"
+
+      - name: Commit and push (assistant-handoff)
+        if: steps.mode.outputs.mode == 'assistant-handoff'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          STATUS=$(git status --porcelain | wc -l | tr -d ' ')
+          if [[ "$STATUS" == "0" ]]; then
+            echo "::notice::assistant-handoff: no changes to commit."
+            exit 0
+          fi
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git add -A
+          MODIFIED=$(git diff --cached --name-only | wc -l | tr -d ' ')
+          git commit -m "implement plan via claude-assistant: ${MODIFIED} files"
+          git push
+          echo "pushed ${MODIFIED} file(s)"
 
       # ======================================================================
       # REVIEW-FIX MODE — fix review feedback on an existing PR
@@ -794,7 +847,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 200 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 500 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: "github-actions"
 
       - name: Check for file changes

--- a/.github/workflows/issue-implementer.yml
+++ b/.github/workflows/issue-implementer.yml
@@ -282,7 +282,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.rf-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 500 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 500 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: "github-actions"
 
       - name: Check for review-fix changes
@@ -794,7 +794,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 200 --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 200 --effort xhigh --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           allowed_bots: "github-actions"
 
       - name: Check for file changes

--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--model claude-opus-4-7 --max-turns 60 --allowedTools "Read,Glob,Grep,Bash"'
+          claude_args: '--model claude-opus-4-7 --max-turns 60 --effort xhigh --allowedTools "Read,Glob,Grep,Bash"'
           allowed_bots: 'github-actions'
 
       - name: Extract plan from execution file

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: "--max-turns 15 --json-schema '${{ steps.schema.outputs.value }}'"
+          claude_args: "--model claude-opus-4-7 --max-turns 15 --effort xhigh --json-schema '${{ steps.schema.outputs.value }}'"
 
       - name: Parse structured verdict
         if: steps.guard.outputs.should-triage == 'true'
@@ -287,7 +287,7 @@ jobs:
               "notes": "Brief description of what you observed"
             }
             ```
-          claude_args: '--max-turns 20'
+          claude_args: '--model claude-opus-4-7 --max-turns 20 --effort xhigh'
 
       - name: Parse reproduction result
         if: steps.reproduce.outcome == 'success'

--- a/.github/workflows/remediation-agent.yml
+++ b/.github/workflows/remediation-agent.yml
@@ -217,7 +217,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.build-prompt.outputs.prompt }}
-          claude_args: '--max-turns 15'
+          claude_args: '--model claude-opus-4-7 --max-turns 15 --effort xhigh'
 
       - name: Check for file changes
         if: steps.guard.outputs.should-remediate == 'true'


### PR DESCRIPTION
## Summary

Two related changes bundled:

### 1. Model + effort bumps (commit 68f20e1)

- 10 codefactory agent calls → `claude-opus-4-7 --effort xhigh`
- `code-review-agent.yml:374` (main review step) → `claude-sonnet-4-6 --effort high`
- `code-review-agent.yml:488` verdict classifier **left on** `claude-haiku-4-5-20251001` (3-turn JSON-schema extractor, opus+xhigh would be pure cost)

### 2. PR-assistant dispatch + turn-budget bump (commit bfc10aa)

The `@claude` PR-comment assistant was hitting `--max-turns 100` limits mid-implementation. Rewired:

- `claude-assistant.yml` **plan mode**: after planning, now dispatches `issue-implementer.yml` via `workflow_dispatch` (passing the built prompt as `assistant_prompt` input) instead of running implementation inline. The implementer runs in its own job with `--max-turns 500`.
- `claude-assistant.yml` **quick mode** (`@claude do/fix/just …`): stays inline, bumped from `--max-turns 100` → `--max-turns 200`.
- `issue-implementer.yml`: new `assistant_prompt` workflow_dispatch input, new `assistant-handoff` mode that handles the claude-assistant handoff (checkout PR branch, run Claude at 500 turns, commit+push).
- `issue-implementer.yml` **issue-mode main run**: `--max-turns 200` → `500`. Rationale: opus+xhigh thinks deeper per turn but real ticket implementations still want wider headroom.

## Changes by file

| file | changes |
| --- | --- |
| claude-assistant.yml | 3 calls → opus-4-7/xhigh; plan mode now dispatches issue-implementer; quick mode max-turns 100→200; post-result handles dispatched path |
| code-review-agent.yml | main review → sonnet-4-6/high; haiku verdict classifier preserved |
| doc-gardening.yml | 1 call → opus-4-7/xhigh |
| issue-implementer.yml | 2 calls → opus-4-7/xhigh; issue-mode max-turns 200→500; new assistant_prompt input + assistant-handoff mode |
| issue-planner.yml | 1 call → opus-4-7/xhigh |
| issue-triage.yml | 2 calls → opus-4-7/xhigh |
| remediation-agent.yml | 1 call → opus-4-7/xhigh |

## Risk tier

T1 — workflow config only, no application code touched. `.github/workflows/**` is in CLAUDE.md's protected-files list; this PR is an explicit human-authorized override.

## Test plan

- [ ] Next `@claude plan …` comment on a PR — claude-assistant plans inline, dispatches issue-implementer, implementation lands in a separate workflow run.
- [ ] Next `@claude do/fix/just …` comment — runs inline at 200 turns, still commits and pushes like before.
- [ ] Next automated issue implementation (from `agent:implement` label) — completes at 500 turns budget.
- [ ] Next PR review run — sonnet-4-6+high on main step, haiku-4-5 still on classifier.
- [ ] `--effort` flag parses without error in action logs (low|medium|high|xhigh|max).